### PR TITLE
build: theme support with custom token-transformer

### DIFF
--- a/proprietary/digid-design-tokens/package.json
+++ b/proprietary/digid-design-tokens/package.json
@@ -17,10 +17,10 @@
     "url": "git@github.com:nl-design-system/rijkshuisstijl-community.git"
   },
   "scripts": {
-    "clean": "rimraf dist/",
+    "clean": "rimraf dist/ tmp/",
     "prebuild": "npm run clean",
     "build": "npm-run-all --sequential build:figma-tokens build:style-dictionary",
-    "build:figma-tokens": "token-transformer --throwErrorWhenNotResolved=true ../logius-design-tokens/src/figma.tokens.json tmp/figma.tokens.json brand,common,components,'change brand/DigiD'",
+    "build:figma-tokens": "node token-transformer.mjs",
     "build:style-dictionary": "style-dictionary build --config ./style-dictionary.config.json",
     "watch": "npm-run-all watch:**",
     "watch:style-dictionary": "chokidar --follow-symlinks --initial --command 'npm run build' 'tmp/*.tokens.json'"

--- a/proprietary/digid-design-tokens/token-transformer.mjs
+++ b/proprietary/digid-design-tokens/token-transformer.mjs
@@ -1,0 +1,11 @@
+import { tokenTransformer } from "../logius-design-tokens/src/token-transformer.mjs";
+import { resolve } from "node:path";
+
+tokenTransformer({
+	input: new URL(
+		"../logius-design-tokens/src/figma.tokens.json",
+		import.meta.url,
+	).pathname,
+	output: new URL("./tmp/figma.tokens.json", import.meta.url).pathname,
+	themes: ["DigiD"],
+});

--- a/proprietary/logius-design-tokens/package.json
+++ b/proprietary/logius-design-tokens/package.json
@@ -17,10 +17,10 @@
     "url": "git@github.com:nl-design-system/rijkshuisstijl-community.git"
   },
   "scripts": {
-    "clean": "rimraf dist/",
+    "clean": "rimraf dist/ tmp/",
     "prebuild": "npm run clean",
     "build": "npm-run-all --sequential build:figma-tokens build:style-dictionary",
-    "build:figma-tokens": "token-transformer --throwErrorWhenNotResolved=true src/figma.tokens.json tmp/figma.tokens.json brand,common,components",
+    "build:figma-tokens": "node token-transformer.mjs",
     "build:style-dictionary": "style-dictionary build --config ./style-dictionary.config.json",
     "watch": "npm-run-all watch:**",
     "watch:style-dictionary": "chokidar --follow-symlinks --initial --command 'npm run build' 'tmp/*.tokens.json'"

--- a/proprietary/logius-design-tokens/src/figma.tokens.json
+++ b/proprietary/logius-design-tokens/src/figma.tokens.json
@@ -5075,7 +5075,7 @@
       }
     }
   },
-  "change brand/DigiD": {
+  "theme/DigiD": {
     "logius": {
       "color": {
         "brand": {
@@ -5150,7 +5150,7 @@
       }
     }
   },
-  "change brand/MijnOverheid": {
+  "theme/MijnOverheid": {
     "logius": {
       "color": {
         "brand": {
@@ -5212,8 +5212,8 @@
       "components/textarea",
       "components/text-input",
       "components/unordered-list",
-      "change brand/DigiD",
-      "change brand/MijnOverheid"
+      "theme/DigiD",
+      "theme/MijnOverheid"
     ]
   }
 }

--- a/proprietary/logius-design-tokens/src/token-transformer.mjs
+++ b/proprietary/logius-design-tokens/src/token-transformer.mjs
@@ -1,0 +1,42 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2023 Frameless B.V.
+ */
+
+import { transformTokens } from "token-transformer";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+export const tokenTransformer = ({ input, output, themes }) => {
+  const rawTokens = JSON.parse(readFileSync(input));
+
+  const sets = Object.keys(rawTokens);
+
+  const themeToSetName = (theme) => `theme/${theme ?? ""}`.toLowerCase();
+  const themeSets = themes.map(themeToSetName);
+
+  const setsToUse = sets.filter(
+    (name) =>
+      !name.toLowerCase().startsWith("theme/") ||
+      (themeSets.length > 0 && themeSets.includes(name.toLowerCase())),
+  );
+  const excludes = [];
+
+  const transformerOptions = {
+    throwErrorWhenNotResolved: true,
+  };
+
+  const resolved = transformTokens(
+    rawTokens,
+    setsToUse,
+    excludes,
+    transformerOptions,
+  );
+
+  mkdirSync(dirname(output), { recursive: true });
+  writeFileSync(output, JSON.stringify(resolved, null, 2), () => {
+    console.log(
+      `Tokens Studio JSON converted to Style Dictionary JSON:\n${output}`,
+    );
+  });
+};

--- a/proprietary/logius-design-tokens/token-transformer.mjs
+++ b/proprietary/logius-design-tokens/token-transformer.mjs
@@ -1,0 +1,7 @@
+import { tokenTransformer } from "./src/token-transformer.mjs";
+
+tokenTransformer({
+	input: new URL("./src/figma.tokens.json", import.meta.url).pathname,
+	output: new URL("./tmp/figma.tokens.json", import.meta.url).pathname,
+	themes: ["Logius"],
+});

--- a/proprietary/mijnoverheid-design-tokens/package.json
+++ b/proprietary/mijnoverheid-design-tokens/package.json
@@ -17,10 +17,10 @@
     "url": "git@github.com:nl-design-system/rijkshuisstijl-community.git"
   },
   "scripts": {
-    "clean": "rimraf dist/",
+    "clean": "rimraf dist/ tmp/",
     "prebuild": "npm run clean",
     "build": "npm-run-all --sequential build:figma-tokens build:style-dictionary",
-    "build:figma-tokens": "token-transformer --throwErrorWhenNotResolved=true ../logius-design-tokens/src/figma.tokens.json tmp/figma.tokens.json brand,common,components,'change brand/MijnOverheid'",
+    "build:figma-tokens": "node token-transformer.mjs",
     "build:style-dictionary": "style-dictionary build --config ./style-dictionary.config.json",
     "watch": "npm-run-all watch:**",
     "watch:style-dictionary": "chokidar --follow-symlinks --initial --command 'npm run build' 'tmp/*.tokens.json'"

--- a/proprietary/mijnoverheid-design-tokens/token-transformer.mjs
+++ b/proprietary/mijnoverheid-design-tokens/token-transformer.mjs
@@ -1,0 +1,10 @@
+import { tokenTransformer } from "../logius-design-tokens/src/token-transformer.mjs";
+
+tokenTransformer({
+	input: new URL(
+		"../logius-design-tokens/src/figma.tokens.json",
+		import.meta.url,
+	).pathname,
+	output: new URL("./tmp/figma.tokens.json", import.meta.url).pathname,
+	themes: ["MijnOverheid"],
+});


### PR DESCRIPTION
All token sets starting with `theme/` are now optional, you can specify one or more themes. For example:

- `themes: ['DigiD']`
- `themes: ['DigiD', 'DigiD (dark mode)']`