### PR TITLE
The Heading story now shows the "Variable Heading" from  Utrecht.

### DIFF
--- a/packages/storybook/config/preview.tsx
+++ b/packages/storybook/config/preview.tsx
@@ -6,12 +6,10 @@ import '@rijkshuisstijl-community/logius-design-tokens/dist/theme.css';
 import '@rijkshuisstijl-community/mijnoverheid-design-tokens/dist/theme.css';
 import '@rijkshuisstijl-community/rivm-design-tokens/dist/theme.css';
 import { withThemeByClassName } from '@storybook/addon-themes';
-import { Preview, StoryContext } from '@storybook/react';
+import { Preview } from '@storybook/react';
 import '@utrecht/component-library-css/dist/html.css';
 import '@utrecht/component-library-css/dist/index.css';
 import { UtrechtDocument } from '@utrecht/web-component-library-react';
-import { renderToStaticMarkup } from 'react-dom/server';
-import { Prettify } from './Prettify';
 
 const preview: Preview = {
   decorators: [
@@ -65,21 +63,27 @@ const preview: Preview = {
     },
     docs: {
       source: {
-        transform(src: string, storyContext: StoryContext) {
-          const render =
-            typeof storyContext.component === 'function'
-              ? storyContext.component
-              : typeof storyContext.component?.render === 'function'
-                ? storyContext.component?.render
-                : null;
+        state: 'open',
 
-          if (render) {
-            const srcString = renderToStaticMarkup(render(storyContext.args));
+        /*
+            Uncomment the transformer to show underlying CSS and HTML
+        */
 
-            return Prettify({ ugly: srcString });
-          }
-          return src;
-        },
+        // transform(src: string, storyContext: StoryContext) {
+        //   const render =
+        //     typeof storyContext.component === 'function'
+        //       ? storyContext.component
+        //       : typeof storyContext.component?.render === 'function'
+        //         ? storyContext.component?.render
+        //         : null;
+
+        //   if (render) {
+        //     const srcString = renderToStaticMarkup(render(storyContext.args));
+
+        //     return Prettify({ ugly: srcString });
+        //   }
+        //   return src;
+        // },
       },
     },
   },

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -27,6 +27,7 @@
     "@nl-rvo/assets": "1.0.0-alpha.360",
     "@rijkshuisstijl-community/assets": "workspace:*",
     "@rijkshuisstijl-community/components-css": "workspace:*",
+    "@rijkshuisstijl-community/components-react": "workspace:*",
     "@rijkshuisstijl-community/design-tokens": "workspace:*",
     "@rijkshuisstijl-community/digid-design-tokens": "workspace:*",
     "@rijkshuisstijl-community/font": "workspace:*",

--- a/packages/storybook/src/community/heading.stories.tsx
+++ b/packages/storybook/src/community/heading.stories.tsx
@@ -1,7 +1,7 @@
 /* @license CC0-1.0 */
 
+import { Heading } from '@rijkshuisstijl-community/components-react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Heading } from '@utrecht/component-library-react/dist/css-module';
 import readme from './heading.md?raw';
 
 const meta = {
@@ -13,27 +13,20 @@ const meta = {
       description: 'Heading level',
       control: { type: 'select' },
       options: [1, 2, 3, 4, 5, 6],
-      defaultValue: 1,
-      table: {
-        category: 'Property',
-      },
     },
-    children: {
-      description: 'Heading text - default webcomponent slot',
-      type: {
-        name: 'string',
-        required: true,
-      },
-      table: {
-        category: 'Webcomponent Slot',
-      },
-      defaultValue: '',
+    appearance: {
+      description: 'Appearance',
+      control: { type: 'select' },
+      options: [
+        undefined,
+        'utrecht-heading-1',
+        'utrecht-heading-2',
+        'utrecht-heading-3',
+        'utrecht-heading-4',
+        'utrecht-heading-5',
+      ],
     },
   },
-  args: {
-    children: '',
-  },
-  tags: ['autodocs'],
   parameters: {
     docs: {
       description: {
@@ -41,7 +34,7 @@ const meta = {
       },
     },
   },
-} as Meta<typeof Heading>;
+} satisfies Meta<typeof Heading>;
 
 export default meta;
 
@@ -83,12 +76,4 @@ export const Heading5: StoryObj<typeof meta> = {
     children: 'Lorem ipsum dolor sit amet, consectetur ad isicing elit, sed do eiusmod',
   },
   name: 'Heading 5',
-};
-
-export const Heading6: StoryObj<typeof meta> = {
-  args: {
-    level: 6,
-    children: 'Lorem ipsum dolor sit amet, consectetur ad isicing elit, sed do eiusmod',
-  },
-  name: 'Heading 6',
 };

--- a/packages/storybook/src/community/heading.stories.tsx
+++ b/packages/storybook/src/community/heading.stories.tsx
@@ -24,6 +24,7 @@ const meta = {
         'utrecht-heading-3',
         'utrecht-heading-4',
         'utrecht-heading-5',
+        'utrecht-heading-6',
       ],
     },
   },
@@ -76,4 +77,11 @@ export const Heading5: StoryObj<typeof meta> = {
     children: 'Lorem ipsum dolor sit amet, consectetur ad isicing elit, sed do eiusmod',
   },
   name: 'Heading 5',
+};
+
+export const Heading6: StoryObj<typeof meta> = {
+  args: {
+    level: 6,
+    children: 'Lorem ipsum dolor sit amet, consectetur ad isicing elit, sed do eiusmod',
+  },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,6 +280,9 @@ importers:
       '@rijkshuisstijl-community/components-css':
         specifier: workspace:*
         version: link:../components-css
+      '@rijkshuisstijl-community/components-react':
+        specifier: workspace:*
+        version: link:../components-react
       '@rijkshuisstijl-community/design-tokens':
         specifier: workspace:*
         version: link:../../proprietary/design-tokens

--- a/proprietary/design-tokens/token-transformer.mjs
+++ b/proprietary/design-tokens/token-transformer.mjs
@@ -25,7 +25,6 @@ const init = async ({ input, output }) => {
     'components/form-field-error-message',
     'components/form-field-option-label',
     'components/form-field-radio-option',
-    'components/heading',
     'components/icon-only-button',
     'components/modal-dialog',
     'components/ordered-list',


### PR DESCRIPTION
- Removed transformer so that the component HTML can be seen in the stroy and not the underlying HTML.
- Added @rijkshuisstijl-community/components-react to packages/storybook dependencies.
- Removed components/heading from token excludes.

PR depends on [485](https://github.com/nl-design-system/rijkshuisstijl-community/pull/485)