### PR TITLE
fix: change checkbox border-width tokens

### DIFF
--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -2379,7 +2379,7 @@
             "type": "color"
           },
           "border-width": {
-            "value": "{rhc.form-control.border-width}",
+            "value": "{rhc.border-width.default}",
             "type": "borderWidth"
           },
           "disabled": {
@@ -2465,7 +2465,7 @@
             "type": "color"
           },
           "border-width": {
-            "value": "{rhc.form-control.border-width}",
+            "value": "{rhc.border-width.default}",
             "type": "borderWidth"
           },
           "disabled": {


### PR DESCRIPTION
Replaced `rhc.form-control.border-width` by `rhc.border-width.default`.

The token was linked to a non-existent Utrecht document token, which resulted in no connection.