### PR TITLE
Aanpassing en common laag

### DIFF
--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -670,7 +670,7 @@
           "value": "1px",
           "type": "borderWidth"
         },
-        "m": {
+        "md": {
           "parent": "core/default",
           "value": "2px",
           "type": "borderWidth"
@@ -836,22 +836,16 @@
       "color": {
         "foreground": {
           "default": {
-            "parent": "mode/light",
-            "value": "{rhc.color.zwart}",
-            "type": "color",
-            "description": "Standaard kleur voor teksten en iconen. Gebruik deze voor body content, titels en labels."
-          },
-          "lint": {
             "value": "{rhc.color.lintblauw.500}",
             "type": "color"
           },
           "subdued": {
             "parent": "mode/light",
-            "value": "{rhc.color.grijs.700}",
+            "value": "{rhc.color.lintblauw.400}",
             "type": "color",
             "description": "Gebruik voor content die extra context biedt, maar niet essentieel is om de interface te begrijpen."
           },
-          "onEmphasis": {
+          "on-color": {
             "parent": "mode/light",
             "value": "{rhc.color.wit}",
             "type": "color",
@@ -1034,7 +1028,7 @@
             "type": "fontSizes"
           }
         },
-        "paragraph": {
+        "body": {
           "intro": {
             "value": "{rhc.font-size.sm.desktop}",
             "type": "fontSizes"
@@ -1046,9 +1040,23 @@
         }
       },
       "line-height": {
-        "paragraph": {
+        "body": {
           "value": "{rhc.line-height.md}",
           "type": "lineHeights"
+        },
+        "heading": {
+          "value": "{rhc.line-height.sm}",
+          "type": "lineHeights"
+        }
+      },
+      "font-weight": {
+        "chosen-bold": {
+          "value": "700",
+          "type": "fontWeights"
+        },
+        "chosen-regular": {
+          "value": "400",
+          "type": "fontWeights"
         }
       }
     }
@@ -1073,7 +1081,7 @@
           "type": "other"
         },
         "outline-width": {
-          "value": "{rhc.border-width.m}",
+          "value": "{rhc.border-width.md}",
           "type": "borderWidth"
         }
       }
@@ -1211,7 +1219,7 @@
           "type": "fontFamilies"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "line-height": {
@@ -1219,7 +1227,7 @@
           "type": "lineHeights"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.regular}",
+          "value": "{rhc.font-weight.chosen-regular}",
           "type": "fontWeights"
         }
       }
@@ -1274,7 +1282,7 @@
         },
         "button": {
           "font-size": {
-            "value": "{rhc.font-size.paragraph.default}",
+            "value": "{rhc.font-size.body.default}",
             "type": "fontSizes"
           },
           "line-height": {
@@ -1321,7 +1329,7 @@
               "type": "color"
             },
             "color": {
-              "value": "{rhc.color.foreground.lint}",
+              "value": "{rhc.color.foreground.default}",
               "type": "color"
             }
           },
@@ -1335,7 +1343,7 @@
               "type": "color"
             },
             "color": {
-              "value": "{rhc.color.foreground.lint}",
+              "value": "{rhc.color.foreground.default}",
               "type": "color"
             }
           },
@@ -1348,7 +1356,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "focus": {
@@ -1361,7 +1369,7 @@
               "type": "color"
             },
             "color": {
-              "value": "{rhc.color.foreground.lint}",
+              "value": "{rhc.color.foreground.default}",
               "type": "color"
             }
           },
@@ -1375,7 +1383,7 @@
               "type": "color"
             },
             "color": {
-              "value": "{rhc.color.foreground.lint}",
+              "value": "{rhc.color.foreground.default}",
               "type": "color"
             }
           },
@@ -1388,7 +1396,7 @@
             "type": "fontFamilies"
           },
           "font-weight": {
-            "value": "{rhc.font-weight.regular}",
+            "value": "{rhc.font-weight.chosen-regular}",
             "type": "fontWeights"
           }
         }
@@ -1404,7 +1412,7 @@
             "type": "fontFamilies"
           },
           "font-weight": {
-            "value": "{rhc.font-weight.bold}",
+            "value": "{rhc.font-weight.chosen-bold}",
             "type": "fontWeights"
           },
           "line-height": {
@@ -1457,7 +1465,7 @@
           "type": "color"
         },
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "info": {
@@ -1470,7 +1478,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -1484,7 +1492,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -1498,7 +1506,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -1512,7 +1520,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -1564,14 +1572,14 @@
     }
   },
   "components/article": {
-      "utrecht": {
-        "article": {
-          "max-inline-size": {
-            "value": "75ch",
-            "type": "spacing"
-          }
+    "utrecht": {
+      "article": {
+        "max-inline-size": {
+          "value": "75ch",
+          "type": "spacing"
         }
       }
+    }
   },
   "components/avatar": {
     "todo": {
@@ -1684,7 +1692,7 @@
       "blockquote": {
         "attribution": {
           "font-size": {
-            "value": "{rhc.font-size.paragraph.default}",
+            "value": "{rhc.font-size.body.default}",
             "type": "fontSizes"
           },
           "font-family": {
@@ -1692,11 +1700,11 @@
             "type": "fontFamilies"
           },
           "line-height": {
-            "value": "{rhc.line-height.paragraph}",
+            "value": "{rhc.line-height.body}",
             "type": "lineHeights"
           },
           "font-weight": {
-            "value": "{rhc.font-weight.regular}",
+            "value": "{rhc.font-weight.chosen-regular}",
             "type": "fontWeights"
           },
           "padding-block-start": {
@@ -1714,19 +1722,19 @@
             "type": "fontFamilies"
           },
           "line-height": {
-            "value": "{rhc.line-height.paragraph}",
+            "value": "{rhc.line-height.body}",
             "type": "lineHeights"
           },
           "font-weight": {
-            "value": "{rhc.font-weight.regular}",
+            "value": "{rhc.font-weight.chosen-regular}",
             "type": "fontWeights"
           },
           "font-size": {
-            "value": "{rhc.font-size.paragraph.intro}",
+            "value": "{rhc.font-size.body.intro}",
             "type": "fontSizes"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -1761,11 +1769,11 @@
     "utrecht": {
       "breadcrumb-nav": {
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "link": {
@@ -1872,7 +1880,7 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.regular}",
+          "value": "{rhc.font-weight.chosen-regular}",
           "type": "fontWeights"
         }
       }
@@ -1916,15 +1924,15 @@
           "type": "fontFamilies"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.bold}",
+          "value": "{rhc.font-weight.chosen-bold}",
           "type": "fontWeights"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "padding-block-end": {
@@ -2067,7 +2075,7 @@
             }
           },
           "font-weight": {
-            "value": "{rhc.font-weight.bold}",
+            "value": "{rhc.font-weight.chosen-bold}",
             "type": "fontWeights"
           },
           "active": {
@@ -2158,7 +2166,7 @@
             }
           },
           "font-weight": {
-            "value": "{rhc.font-weight.bold}",
+            "value": "{rhc.font-weight.chosen-bold}",
             "type": "fontWeights"
           },
           "active": {
@@ -2190,7 +2198,7 @@
             "type": "fontSizes"
           },
           "font-weight": {
-            "value": "{rhc.font-weight.bold}",
+            "value": "{rhc.font-weight.chosen-bold}",
             "type": "fontWeights"
           },
           "hover": {
@@ -2361,7 +2369,7 @@
             "type": "color"
           },
           "border-width": {
-            "value": "{rhc.border-width.m}",
+            "value": "{rhc.border-width.md}",
             "type": "borderWidth"
           }
         },
@@ -2408,7 +2416,7 @@
           },
           "focus": {
             "border-width": {
-              "value": "{rhc.border-width.m}",
+              "value": "{rhc.border-width.md}",
               "type": "borderWidth"
             },
             "background-color": {
@@ -2542,7 +2550,7 @@
               "type": "color"
             },
             "border-width": {
-              "value": "{rhc.border-width.m}",
+              "value": "{rhc.border-width.md}",
               "type": "borderWidth"
             }
           }
@@ -2604,11 +2612,11 @@
     "utrecht": {
       "counter-badge": {
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "min-block-size": {
@@ -2620,7 +2628,7 @@
           "type": "sizing"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.bold}",
+          "value": "{rhc.font-weight.chosen-bold}",
           "type": "fontWeights"
         },
         "border-width": {
@@ -2932,7 +2940,7 @@
           "type": "fontFamilies"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "line-height": {
@@ -2972,11 +2980,11 @@
           "type": "fontFamilies"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.regular}",
+          "value": "{rhc.font-weight.chosen-regular}",
           "type": "fontWeights"
         },
         "margin-block-end": {
@@ -2994,7 +3002,7 @@
     "utrecht": {
       "form-field-label": {
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "font-family": {
@@ -3002,11 +3010,11 @@
           "type": "fontFamilies"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.bold}",
+          "value": "{rhc.font-weight.chosen-bold}",
           "type": "fontWeights"
         },
         "line-height": {
@@ -3016,19 +3024,37 @@
       }
     }
   },
+  "components/form-label": {
+    "utrecht": {
+      "form-label": {
+        "color": {
+          "value": "{rhc.color.foreground.default}",
+          "type": "color"
+        },
+        "font-size": {
+          "value": "{rhc.font-size.body.default}",
+          "type": "fontSizes"
+        },
+        "font-weight": {
+          "value": "{rhc.font-weight.chosen-bold}",
+          "type": "fontWeights"
+        }
+      }
+    }
+  },
   "components/form-field-option-label": {
     "todo": {
       "form-field-option-label": {
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "font-family": {
@@ -3036,7 +3062,7 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.regular}",
+          "value": "{rhc.font-weight.chosen-regular}",
           "type": "fontWeights"
         },
         "disabled": {
@@ -3062,7 +3088,7 @@
     "utrecht": {
       "heading-1": {
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "font-family": {
@@ -3070,11 +3096,11 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.bold}",
+          "value": "{rhc.font-weight.chosen-bold}",
           "type": "fontWeights"
         },
         "line-height": {
-          "value": "{rhc.line-height.sm}",
+          "value": "{rhc.line-height.heading}",
           "type": "lineHeights"
         },
         "font-size": {
@@ -3092,7 +3118,7 @@
       },
       "heading-2": {
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "font-family": {
@@ -3100,11 +3126,11 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.bold}",
+          "value": "{rhc.font-weight.chosen-bold}",
           "type": "fontWeights"
         },
         "line-height": {
-          "value": "{rhc.line-height.sm}",
+          "value": "{rhc.line-height.heading}",
           "type": "lineHeights"
         },
         "font-size": {
@@ -3122,7 +3148,7 @@
       },
       "heading-3": {
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "font-family": {
@@ -3130,11 +3156,11 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.bold}",
+          "value": "{rhc.font-weight.chosen-bold}",
           "type": "fontWeights"
         },
         "line-height": {
-          "value": "{rhc.line-height.sm}",
+          "value": "{rhc.line-height.heading}",
           "type": "lineHeights"
         },
         "font-size": {
@@ -3152,7 +3178,7 @@
       },
       "heading-4": {
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "font-family": {
@@ -3160,11 +3186,11 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.bold}",
+          "value": "{rhc.font-weight.chosen-bold}",
           "type": "fontWeights"
         },
         "line-height": {
-          "value": "{rhc.line-height.sm}",
+          "value": "{rhc.line-height.heading}",
           "type": "lineHeights"
         },
         "font-size": {
@@ -3182,7 +3208,7 @@
       },
       "heading-5": {
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "font-family": {
@@ -3190,11 +3216,11 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.bold}",
+          "value": "{rhc.font-weight.chosen-bold}",
           "type": "fontWeights"
         },
         "line-height": {
-          "value": "{rhc.line-height.sm}",
+          "value": "{rhc.line-height.heading}",
           "type": "lineHeights"
         },
         "font-size": {
@@ -3329,15 +3355,15 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.regular}",
+          "value": "{rhc.font-weight.chosen-regular}",
           "type": "fontWeights"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         }
       }
@@ -3611,7 +3637,7 @@
           }
         },
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "font-family": {
@@ -3619,15 +3645,15 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.regular}",
+          "value": "{rhc.font-weight.chosen-regular}",
           "type": "fontWeights"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         }
       }
@@ -3945,7 +3971,7 @@
     "utrecht": {
       "paragraph": {
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "font-family": {
@@ -3953,15 +3979,15 @@
           "type": "fontFamilies"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.regular}",
+          "value": "{rhc.font-weight.chosen-regular}",
           "type": "fontWeights"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "margin-block-end": {
@@ -3974,37 +4000,37 @@
         },
         "lead": {
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "font-size": {
-            "value": "{rhc.font-size.paragraph.intro}",
+            "value": "{rhc.font-size.body.intro}",
             "type": "fontSizes"
           },
           "font-weight": {
-            "value": "{rhc.font-weight.regular}",
+            "value": "{rhc.font-weight.chosen-regular}",
             "type": "fontWeights"
           },
           "line-height": {
-            "value": "{rhc.line-height.paragraph}",
+            "value": "{rhc.line-height.body}",
             "type": "lineHeights"
           }
         },
         "small": {
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "font-size": {
-            "value": "{rhc.font-size.paragraph.default}",
+            "value": "{rhc.font-size.body.default}",
             "type": "fontSizes"
           },
           "font-weight": {
-            "value": "{rhc.font-weight.regular}",
+            "value": "{rhc.font-weight.chosen-regular}",
             "type": "fontWeights"
           },
           "line-height": {
-            "value": "{rhc.line-height.paragraph}",
+            "value": "{rhc.line-height.body}",
             "type": "lineHeights"
           }
         }
@@ -4070,7 +4096,7 @@
             "type": "color"
           },
           "border-width": {
-            "value": "{rhc.border-width.m}",
+            "value": "{rhc.border-width.md}",
             "type": "borderWidth"
           }
         },
@@ -4147,7 +4173,7 @@
               "type": "color"
             },
             "border-width": {
-              "value": "{rhc.border-width.m}",
+              "value": "{rhc.border-width.md}",
               "type": "borderWidth"
             }
           },
@@ -4235,7 +4261,7 @@
           "type": "color"
         },
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "invalid": {
@@ -4248,7 +4274,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "border-width": {
@@ -4266,11 +4292,11 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "border-width": {
-            "value": "{rhc.border-width.m}",
+            "value": "{rhc.border-width.md}",
             "type": "borderWidth"
           }
         },
@@ -4298,7 +4324,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "border-width": {
@@ -4339,15 +4365,15 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.regular}",
+          "value": "{rhc.font-weight.chosen-regular}",
           "type": "fontWeights"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "max-inline-size": {
@@ -4365,7 +4391,7 @@
           "type": "color"
         },
         "block-size": {
-          "value": "{rhc.border-width.m}",
+          "value": "{rhc.border-width.md}",
           "type": "sizing"
         },
         "margin-block-end": {
@@ -4384,7 +4410,7 @@
       "sidenav": {
         "link": {
           "line-height": {
-            "value": "{rhc.line-height.paragraph}",
+            "value": "{rhc.line-height.body}",
             "type": "lineHeights"
           },
           "icon": {
@@ -4398,7 +4424,7 @@
             }
           },
           "font-size": {
-            "value": "{rhc.font-size.paragraph.default}",
+            "value": "{rhc.font-size.body.default}",
             "type": "fontSizes"
           },
           "font-family": {
@@ -4406,16 +4432,16 @@
             "type": "fontFamilies"
           },
           "font-weight": {
-            "value": "{rhc.font-weight.regular}",
+            "value": "{rhc.font-weight.chosen-regular}",
             "type": "fontWeights"
           },
           "current": {
             "font-weight": {
-              "value": "{rhc.font-weight.bold}",
+              "value": "{rhc.font-weight.chosen-bold}",
               "type": "fontWeights"
             },
             "color": {
-              "value": "{rhc.color.foreground.lint}",
+              "value": "{rhc.color.foreground.default}",
               "type": "color"
             }
           },
@@ -4486,7 +4512,7 @@
     "utrecht": {
       "skip-link": {
         "font-weight": {
-          "value": "{rhc.font-weight.bold}",
+          "value": "{rhc.font-weight.chosen-bold}",
           "type": "fontWeights"
         },
         "font-family": {
@@ -4494,11 +4520,11 @@
           "type": "fontFamilies"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "min-block-size": {
@@ -4535,7 +4561,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "text-decoration": {
@@ -4556,7 +4582,7 @@
           "type": "color"
         },
         "border-width": {
-          "value": "{rhc.border-width.m}",
+          "value": "{rhc.border-width.md}",
           "type": "borderWidth"
         },
         "box-block-end-shadow": {
@@ -4581,15 +4607,15 @@
     "utrecht": {
       "status-badge": {
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.bold}",
+          "value": "{rhc.font-weight.chosen-bold}",
           "type": "fontWeights"
         },
         "border-width": {
@@ -4622,7 +4648,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -4636,7 +4662,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -4650,7 +4676,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -4664,7 +4690,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -4677,7 +4703,7 @@
           "type": "color"
         },
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         }
       }
@@ -4692,7 +4718,7 @@
         },
         "item-value": {
           "font-weight": {
-            "value": "{rhc.font-weight.regular}",
+            "value": "{rhc.font-weight.chosen-regular}",
             "type": "fontWeights"
           },
           "row": {
@@ -4732,7 +4758,7 @@
         },
         "item-key": {
           "font-weight": {
-            "value": "{rhc.font-weight.bold}",
+            "value": "{rhc.font-weight.chosen-bold}",
             "type": "fontWeights"
           },
           "row": {
@@ -4780,16 +4806,16 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "item-action": {
@@ -4836,11 +4862,11 @@
       "table": {
         "header-cell": {
           "line-height": {
-            "value": "{rhc.line-height.paragraph}",
+            "value": "{rhc.line-height.body}",
             "type": "lineHeights"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "font-family": {
@@ -4848,11 +4874,11 @@
             "type": "fontFamilies"
           },
           "font-weight": {
-            "value": "{rhc.font-weight.bold}",
+            "value": "{rhc.font-weight.chosen-bold}",
             "type": "fontWeights"
           },
           "font-size": {
-            "value": "{rhc.font-size.paragraph.default}",
+            "value": "{rhc.font-size.body.default}",
             "type": "fontSizes"
           }
         },
@@ -4866,7 +4892,7 @@
             "type": "spacing"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "font-family": {
@@ -4874,7 +4900,7 @@
             "type": "fontFamilies"
           },
           "font-weight": {
-            "value": "{rhc.font-weight.bold}",
+            "value": "{rhc.font-weight.chosen-bold}",
             "type": "fontWeights"
           },
           "font-size": {
@@ -4906,7 +4932,7 @@
         },
         "data-cell": {
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "font-family": {
@@ -4914,21 +4940,21 @@
             "type": "fontFamilies"
           },
           "font-weight": {
-            "value": "{rhc.font-weight.regular}",
+            "value": "{rhc.font-weight.chosen-regular}",
             "type": "fontWeights"
           },
           "line-height": {
-            "value": "{rhc.line-height.paragraph}",
+            "value": "{rhc.line-height.body}",
             "type": "lineHeights"
           },
           "font-size": {
-            "value": "{rhc.font-size.paragraph.default}",
+            "value": "{rhc.font-size.body.default}",
             "type": "fontSizes"
           }
         },
         "header": {
           "border-block-end-width": {
-            "value": "{rhc.border-width.m}",
+            "value": "{rhc.border-width.md}",
             "type": "borderWidth"
           },
           "border-block-end-color": {
@@ -4970,15 +4996,15 @@
         },
         "footer-cell": {
           "font-weight": {
-            "value": "{rhc.font-weight.bold}",
+            "value": "{rhc.font-weight.chosen-bold}",
             "type": "fontWeights"
           },
           "font-size": {
-            "value": "{rhc.font-size.paragraph.default}",
+            "value": "{rhc.font-size.body.default}",
             "type": "fontSizes"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "font-family": {
@@ -4986,7 +5012,7 @@
             "type": "fontFamilies"
           },
           "line-height": {
-            "value": "{rhc.line-height.paragraph}",
+            "value": "{rhc.line-height.body}",
             "type": "lineHeights"
           }
         },
@@ -5137,7 +5163,7 @@
           "type": "color"
         },
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "invalid": {
@@ -5150,7 +5176,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "border-width": {
@@ -5174,11 +5200,11 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "border-width": {
-            "value": "{rhc.border-width.m}",
+            "value": "{rhc.border-width.md}",
             "type": "borderWidth"
           }
         },
@@ -5206,7 +5232,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -5220,7 +5246,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "border-width": {
@@ -5245,15 +5271,15 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.regular}",
+          "value": "{rhc.font-weight.chosen-regular}",
           "type": "fontWeights"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         }
       }
@@ -5271,15 +5297,15 @@
           "type": "fontFamilies"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.regular}",
+          "value": "{rhc.font-weight.chosen-regular}",
           "type": "fontWeights"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "max-inline-size": {
@@ -5311,7 +5337,7 @@
           "type": "color"
         },
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "invalid": {
@@ -5324,7 +5350,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "border-width": {
@@ -5348,7 +5374,7 @@
         },
         "focus": {
           "border-width": {
-            "value": "{rhc.border-width.m}",
+            "value": "{rhc.border-width.md}",
             "type": "borderWidth"
           },
           "background-color": {
@@ -5360,7 +5386,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -5388,7 +5414,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -5406,7 +5432,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         }
@@ -5457,7 +5483,7 @@
           "type": "spacing"
         },
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "font-family": {
@@ -5465,15 +5491,15 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.regular}",
+          "value": "{rhc.font-weight.chosen-regular}",
           "type": "fontWeights"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "item": {
@@ -5492,31 +5518,13 @@
         },
         "marker": {
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "border-color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
-        }
-      }
-    }
-  },
-  "components/form-label": {
-    "utrecht": {
-      "form-label": {
-        "color": {
-          "value": "{rhc.color.foreground.lint}",
-          "type": "color"
-        },
-        "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
-          "type": "fontSizes"
-        },
-        "font-weight": {
-          "value": "{rhc.font-weight.bold}",
-          "type": "fontWeights"
         }
       }
     }
@@ -5559,6 +5567,7 @@
       "components/form-field-description",
       "components/form-field-error-message",
       "components/form-field-label",
+      "components/form-label",
       "components/form-field-option-label",
       "components/form-field-radio-option",
       "components/heading",
@@ -5583,8 +5592,7 @@
       "components/textarea",
       "components/text-input",
       "components/toolbar-button",
-      "components/unordered-list",
-      "components/form-label"
+      "components/unordered-list"
     ]
   }
 }


### PR DESCRIPTION
- de waarde van` rhc.color.foreground.subdued `aangepast naar lintblauw ipv grijs
- `rhc.color.foreground.default` is nu lintblauw en rhc.color.foreground.lint bestaat niet meer
- `rhc.font-weight.chosen-*` tokens toegevoegd op de commonlaag
- Alle component tokens die eerder verwezen naar `rhc.fontweight.regular `of `-.bold `laten verwijzen naar `.chosen-* `op het logo na. 
- `rhc.line-height.heading `toegevoegd
- heading component font-weight tokens verwezen naar `rhc.line-height.heading`
-` rhc.*.paragraph.* `tokens hernoemt naar `rhc.*.body.*`
- `rhc.border-width.m` hernoemd naar `rhc.border-width.md`
