### PR TITLE
aline/commonlaag-aanpassen-poging-2

### DIFF
--- a/packages/components-css/table/index.scss
+++ b/packages/components-css/table/index.scss
@@ -11,7 +11,7 @@
     }
   }
   &__cell {
-    color: var(--rhc-color-foreground-lint);
+    color: var(--utrecht-table-data-cell-color);
   }
 
   &__header {

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -702,10 +702,6 @@
           "value": "400",
           "type": "fontWeights"
         },
-        "chosen-regular": {
-          "value": "400",
-          "type": "fontWeights"
-        },
         "light": {
           "value": "300",
           "type": "fontWeights"
@@ -840,22 +836,16 @@
       "color": {
         "foreground": {
           "default": {
-            "parent": "mode/light",
-            "value": "{rhc.color.zwart}",
-            "type": "color",
-            "description": "Standaard kleur voor teksten en iconen. Gebruik deze voor body content, titels en labels."
-          },
-          "lint": {
             "value": "{rhc.color.lintblauw.500}",
             "type": "color"
           },
           "subdued": {
             "parent": "mode/light",
-            "value": "{rhc.color.grijs.700}",
+            "value": "{rhc.color.lintblauw.400}",
             "type": "color",
             "description": "Gebruik voor content die extra context biedt, maar niet essentieel is om de interface te begrijpen."
           },
-          "onEmphasis": {
+          "on-color": {
             "parent": "mode/light",
             "value": "{rhc.color.wit}",
             "type": "color",
@@ -1054,6 +1044,22 @@
           "value": "{rhc.line-height.md}",
           "type": "lineHeights"
         }
+      },
+      "font-weight": {
+        "body": {
+          "strong": {
+            "value": "{rhc.font-weight.bold}",
+            "type": "fontWeights"
+          },
+          "normal": {
+            "value": "{rhc.font-weight.body.strong}",
+            "type": "fontWeights"
+          }
+        },
+        "heading": {
+          "value": "{rhc.font-weight.bold}",
+          "type": "fontWeights"
+        }
       }
     }
   },
@@ -1205,7 +1211,7 @@
           "type": "lineHeights"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.regular}",
+          "value": "{rhc.font-weight.body.normal}",
           "type": "fontWeights"
         }
       }
@@ -1219,7 +1225,7 @@
           "type": "borderRadius"
         },
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "row-gap": {
@@ -1321,7 +1327,7 @@
               "type": "color"
             },
             "color": {
-              "value": "{rhc.color.foreground.lint}",
+              "value": "{rhc.color.foreground.default}",
               "type": "color"
             }
           },
@@ -1331,7 +1337,7 @@
               "type": "color"
             },
             "color": {
-              "value": "{rhc.color.foreground.lint}",
+              "value": "{rhc.color.foreground.default}",
               "type": "color"
             }
           },
@@ -1348,7 +1354,7 @@
             "type": "borderWidth"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "focus": {
@@ -1361,7 +1367,7 @@
               "type": "color"
             },
             "color": {
-              "value": "{rhc.color.foreground.lint}",
+              "value": "{rhc.color.foreground.default}",
               "type": "color"
             }
           },
@@ -1375,7 +1381,7 @@
               "type": "color"
             },
             "color": {
-              "value": "{rhc.color.foreground.lint}",
+              "value": "{rhc.color.foreground.default}",
               "type": "color"
             }
           },
@@ -1384,7 +1390,7 @@
             "type": "fontFamilies"
           },
           "font-weight": {
-            "value": "{rhc.font-weight.chosen-regular}",
+            "value": "{rhc.font-weight.body.normal}",
             "type": "fontWeights"
           }
         }
@@ -1400,7 +1406,7 @@
             "type": "fontFamilies"
           },
           "font-weight": {
-            "value": "{rhc.font-weight.bold}",
+            "value": "{rhc.font-weight.heading}",
             "type": "fontWeights"
           },
           "line-height": {
@@ -1453,7 +1459,7 @@
           "type": "color"
         },
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "info": {
@@ -1466,7 +1472,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -1480,7 +1486,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -1494,7 +1500,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -1508,7 +1514,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -1692,7 +1698,7 @@
             "type": "lineHeights"
           },
           "font-weight": {
-            "value": "{rhc.font-weight.regular}",
+            "value": "{rhc.font-weight.body.normal}",
             "type": "fontWeights"
           },
           "padding-block-start": {
@@ -1714,7 +1720,7 @@
             "type": "lineHeights"
           },
           "font-weight": {
-            "value": "{rhc.font-weight.regular}",
+            "value": "{rhc.font-weight.body.normal}",
             "type": "fontWeights"
           },
           "font-size": {
@@ -1722,7 +1728,7 @@
             "type": "fontSizes"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -1884,7 +1890,7 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.regular}",
+          "value": "{rhc.font-weight.body.normal}",
           "type": "fontWeights"
         }
       }
@@ -1932,7 +1938,7 @@
           "type": "fontSizes"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.bold}",
+          "value": "{rhc.font-weight.body.strong}",
           "type": "fontWeights"
         },
         "line-height": {
@@ -2079,7 +2085,7 @@
             }
           },
           "font-weight": {
-            "value": "{rhc.font-weight.bold}",
+            "value": "{rhc.font-weight.body.strong}",
             "type": "fontWeights"
           },
           "active": {
@@ -2170,7 +2176,7 @@
             }
           },
           "font-weight": {
-            "value": "{rhc.font-weight.bold}",
+            "value": "{rhc.font-weight.body.strong}",
             "type": "fontWeights"
           },
           "active": {
@@ -2202,7 +2208,7 @@
             "type": "fontSizes"
           },
           "font-weight": {
-            "value": "{rhc.font-weight.bold}",
+            "value": "{rhc.font-weight.body.strong}",
             "type": "fontWeights"
           },
           "hover": {
@@ -2632,7 +2638,7 @@
           "type": "sizing"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.bold}",
+          "value": "{rhc.font-weight.body.strong}",
           "type": "fontWeights"
         },
         "border-width": {
@@ -2988,7 +2994,7 @@
           "type": "fontSizes"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.regular}",
+          "value": "{rhc.font-weight.body.normal}",
           "type": "fontWeights"
         },
         "margin-block-end": {
@@ -3006,7 +3012,7 @@
     "utrecht": {
       "form-field-label": {
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "font-family": {
@@ -3018,7 +3024,7 @@
           "type": "fontSizes"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.bold}",
+          "value": "{rhc.font-weight.body.strong}",
           "type": "fontWeights"
         },
         "line-height": {
@@ -3032,7 +3038,7 @@
     "todo": {
       "form-field-option-label": {
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "font-size": {
@@ -3048,7 +3054,7 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.regular}",
+          "value": "{rhc.font-weight.body.normal}",
           "type": "fontWeights"
         },
         "disabled": {
@@ -3068,7 +3074,7 @@
           "type": "spacing"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.regular}",
+          "value": "{rhc.font-weight.body.normal}",
           "type": "fontWeights"
         },
         "row-gap": {
@@ -3082,7 +3088,7 @@
     "utrecht": {
       "form-label": {
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "font-size": {
@@ -3090,7 +3096,7 @@
           "type": "fontSizes"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.bold}",
+          "value": "{rhc.font-weight.body.strong}",
           "type": "fontWeights"
         }
       }
@@ -3100,7 +3106,7 @@
     "utrecht": {
       "heading-1": {
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "font-family": {
@@ -3108,7 +3114,7 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.bold}",
+          "value": "{rhc.font-weight.body.strong}",
           "type": "fontWeights"
         },
         "line-height": {
@@ -3130,7 +3136,7 @@
       },
       "heading-2": {
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "font-family": {
@@ -3138,7 +3144,7 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.bold}",
+          "value": "{rhc.font-weight.body.strong}",
           "type": "fontWeights"
         },
         "line-height": {
@@ -3160,7 +3166,7 @@
       },
       "heading-3": {
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "font-family": {
@@ -3168,7 +3174,7 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.bold}",
+          "value": "{rhc.font-weight.body.strong}",
           "type": "fontWeights"
         },
         "line-height": {
@@ -3190,7 +3196,7 @@
       },
       "heading-4": {
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "font-family": {
@@ -3198,7 +3204,7 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.bold}",
+          "value": "{rhc.font-weight.body.strong}",
           "type": "fontWeights"
         },
         "line-height": {
@@ -3220,7 +3226,7 @@
       },
       "heading-5": {
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "font-family": {
@@ -3228,7 +3234,7 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.bold}",
+          "value": "{rhc.font-weight.body.strong}",
           "type": "fontWeights"
         },
         "line-height": {
@@ -3255,7 +3261,7 @@
       "hero": {
         "heading": {
           "font-weight": {
-            "value": "{rhc.font-weight.bold}",
+            "value": "{rhc.font-weight.body.strong}",
             "type": "fontWeights"
           },
           "line-height": {
@@ -3273,7 +3279,7 @@
         },
         "subtext": {
           "font-weight": {
-            "value": "{rhc.font-weight.regular}",
+            "value": "{rhc.font-weight.body.normal}",
             "type": "fontWeights"
           },
           "line-height": {
@@ -3295,7 +3301,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.onEmphasis}",
+            "value": "{rhc.color.foreground.on-color}",
             "type": "color"
           },
           "row-gap": {
@@ -3451,7 +3457,7 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.regular}",
+          "value": "{rhc.font-weight.body.normal}",
           "type": "fontWeights"
         },
         "font-size": {
@@ -3759,7 +3765,7 @@
           }
         },
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "font-family": {
@@ -3767,7 +3773,7 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.regular}",
+          "value": "{rhc.font-weight.body.normal}",
           "type": "fontWeights"
         },
         "font-size": {
@@ -4093,7 +4099,7 @@
     "utrecht": {
       "paragraph": {
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "font-family": {
@@ -4105,7 +4111,7 @@
           "type": "fontSizes"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.regular}",
+          "value": "{rhc.font-weight.body.normal}",
           "type": "fontWeights"
         },
         "line-height": {
@@ -4122,7 +4128,7 @@
         },
         "lead": {
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "font-size": {
@@ -4130,7 +4136,7 @@
             "type": "fontSizes"
           },
           "font-weight": {
-            "value": "{rhc.font-weight.regular}",
+            "value": "{rhc.font-weight.body.normal}",
             "type": "fontWeights"
           },
           "line-height": {
@@ -4140,7 +4146,7 @@
         },
         "small": {
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "font-size": {
@@ -4148,7 +4154,7 @@
             "type": "fontSizes"
           },
           "font-weight": {
-            "value": "{rhc.font-weight.regular}",
+            "value": "{rhc.font-weight.body.normal}",
             "type": "fontWeights"
           },
           "line-height": {
@@ -4387,7 +4393,7 @@
           "type": "color"
         },
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "invalid": {
@@ -4400,7 +4406,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "border-width": {
@@ -4418,7 +4424,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "border-width": {
@@ -4450,7 +4456,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "border-width": {
@@ -4491,7 +4497,7 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.regular}",
+          "value": "{rhc.font-weight.body.normal}",
           "type": "fontWeights"
         },
         "line-height": {
@@ -4558,16 +4564,16 @@
             "type": "fontFamilies"
           },
           "font-weight": {
-            "value": "{rhc.font-weight.regular}",
+            "value": "{rhc.font-weight.body.normal}",
             "type": "fontWeights"
           },
           "current": {
             "font-weight": {
-              "value": "{rhc.font-weight.bold}",
+              "value": "{rhc.font-weight.body.strong}",
               "type": "fontWeights"
             },
             "color": {
-              "value": "{rhc.color.foreground.lint}",
+              "value": "{rhc.color.foreground.default}",
               "type": "color"
             }
           },
@@ -4638,7 +4644,7 @@
     "utrecht": {
       "skip-link": {
         "font-weight": {
-          "value": "{rhc.font-weight.bold}",
+          "value": "{rhc.font-weight.body.strong}",
           "type": "fontWeights"
         },
         "font-family": {
@@ -4695,7 +4701,7 @@
             "type": "borderWidth"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "text-decoration": {
@@ -4759,7 +4765,7 @@
           "type": "lineHeights"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.bold}",
+          "value": "{rhc.font-weight.body.strong}",
           "type": "fontWeights"
         },
         "border-width": {
@@ -4792,7 +4798,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -4806,7 +4812,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -4820,7 +4826,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -4834,7 +4840,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -4847,7 +4853,7 @@
           "type": "color"
         },
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         }
       }
@@ -4862,7 +4868,7 @@
         },
         "item-value": {
           "font-weight": {
-            "value": "{rhc.font-weight.regular}",
+            "value": "{rhc.font-weight.body.normal}",
             "type": "fontWeights"
           },
           "row": {
@@ -4902,7 +4908,7 @@
         },
         "item-key": {
           "font-weight": {
-            "value": "{rhc.font-weight.bold}",
+            "value": "{rhc.font-weight.body.strong}",
             "type": "fontWeights"
           },
           "row": {
@@ -4950,7 +4956,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -5010,7 +5016,7 @@
             "type": "lineHeights"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "font-family": {
@@ -5018,7 +5024,7 @@
             "type": "fontFamilies"
           },
           "font-weight": {
-            "value": "{rhc.font-weight.bold}",
+            "value": "{rhc.font-weight.body.strong}",
             "type": "fontWeights"
           },
           "font-size": {
@@ -5036,7 +5042,7 @@
             "type": "spacing"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "font-family": {
@@ -5044,7 +5050,7 @@
             "type": "fontFamilies"
           },
           "font-weight": {
-            "value": "{rhc.font-weight.bold}",
+            "value": "{rhc.font-weight.body.strong}",
             "type": "fontWeights"
           },
           "font-size": {
@@ -5072,7 +5078,7 @@
         },
         "data-cell": {
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "font-family": {
@@ -5080,7 +5086,7 @@
             "type": "fontFamilies"
           },
           "font-weight": {
-            "value": "{rhc.font-weight.regular}",
+            "value": "{rhc.font-weight.body.normal}",
             "type": "fontWeights"
           },
           "line-height": {
@@ -5136,7 +5142,7 @@
         },
         "footer-cell": {
           "font-weight": {
-            "value": "{rhc.font-weight.bold}",
+            "value": "{rhc.font-weight.body.strong}",
             "type": "fontWeights"
           },
           "font-size": {
@@ -5144,7 +5150,7 @@
             "type": "fontSizes"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "font-family": {
@@ -5303,7 +5309,7 @@
           "type": "color"
         },
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "invalid": {
@@ -5316,7 +5322,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "border-width": {
@@ -5340,7 +5346,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "border-width": {
@@ -5372,7 +5378,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -5386,7 +5392,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "border-width": {
@@ -5411,7 +5417,7 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.regular}",
+          "value": "{rhc.font-weight.body.normal}",
           "type": "fontWeights"
         },
         "line-height": {
@@ -5441,7 +5447,7 @@
           "type": "fontSizes"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.regular}",
+          "value": "{rhc.font-weight.body.normal}",
           "type": "fontWeights"
         },
         "line-height": {
@@ -5477,7 +5483,7 @@
           "type": "color"
         },
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "invalid": {
@@ -5490,7 +5496,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "border-width": {
@@ -5526,7 +5532,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -5554,7 +5560,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         },
@@ -5572,7 +5578,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         }
@@ -5624,7 +5630,7 @@
         },
         "hover": {
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "background-color": {
@@ -5693,7 +5699,7 @@
           "type": "spacing"
         },
         "color": {
-          "value": "{rhc.color.foreground.lint}",
+          "value": "{rhc.color.foreground.default}",
           "type": "color"
         },
         "font-family": {
@@ -5701,7 +5707,7 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.regular}",
+          "value": "{rhc.font-weight.body.normal}",
           "type": "fontWeights"
         },
         "font-size": {
@@ -5728,11 +5734,11 @@
         },
         "marker": {
           "color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           },
           "border-color": {
-            "value": "{rhc.color.foreground.lint}",
+            "value": "{rhc.color.foreground.default}",
             "type": "color"
           }
         }

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -670,7 +670,7 @@
           "value": "1px",
           "type": "borderWidth"
         },
-        "m": {
+        "md": {
           "parent": "core/default",
           "value": "2px",
           "type": "borderWidth"
@@ -809,23 +809,23 @@
     "rhc": {
       "size": {
         "quarter-lint": {
-          "value": "12px",
+          "value": "0.75rem",
           "type": "dimension"
         },
         "half-lint": {
-          "value": "24px",
+          "value": "1.5rem",
           "type": "dimension"
         },
         "lint": {
-          "value": "48px",
+          "value": "3rem",
           "type": "dimension"
         },
         "2-lint": {
-          "value": "96px",
+          "value": "6rem",
           "type": "dimension"
         },
         "3-lint": {
-          "value": "1440px",
+          "value": "12rem",
           "type": "dimension"
         }
       }
@@ -991,12 +991,12 @@
     "rhc": {
       "size": {
         "target": {
-          "value": "48px",
+          "value": "3rem",
           "type": "sizing"
         },
         "icon": {
           "functional": {
-            "value": "24px",
+            "value": "1.5rem",
             "type": "sizing"
           }
         }
@@ -1028,7 +1028,7 @@
             "type": "fontSizes"
           }
         },
-        "paragraph": {
+        "body": {
           "intro": {
             "value": "{rhc.font-size.sm.desktop}",
             "type": "fontSizes"
@@ -1040,8 +1040,12 @@
         }
       },
       "line-height": {
-        "paragraph": {
+        "body": {
           "value": "{rhc.line-height.md}",
+          "type": "lineHeights"
+        },
+        "heading": {
+          "value": "{rhc.line-height.sm}",
           "type": "lineHeights"
         }
       },
@@ -1083,7 +1087,7 @@
           "type": "other"
         },
         "outline-width": {
-          "value": "{rhc.border-width.m}",
+          "value": "{rhc.border-width.md}",
           "type": "borderWidth"
         }
       }
@@ -1203,7 +1207,7 @@
           "type": "fontFamilies"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "line-height": {
@@ -1280,7 +1284,7 @@
         },
         "button": {
           "font-size": {
-            "value": "{rhc.font-size.paragraph.default}",
+            "value": "{rhc.font-size.body.default}",
             "type": "fontSizes"
           },
           "line-height": {
@@ -1520,7 +1524,7 @@
         },
         "icon": {
           "inset-block-start": {
-            "value": "3px",
+            "value": "0.188rem",
             "type": "spacing"
           },
           "info": {
@@ -1592,7 +1596,7 @@
         },
         "icon": {
           "icon-size": {
-            "value": "{rhc.icon.functional.size}",
+            "value": "{rhc.size.icon.functional}",
             "type": "sizing"
           }
         },
@@ -1686,7 +1690,7 @@
       "blockquote": {
         "attribution": {
           "font-size": {
-            "value": "{rhc.font-size.paragraph.default}",
+            "value": "{rhc.font-size.body.default}",
             "type": "fontSizes"
           },
           "font-family": {
@@ -1694,7 +1698,7 @@
             "type": "fontFamilies"
           },
           "line-height": {
-            "value": "{rhc.line-height.paragraph}",
+            "value": "{rhc.line-height.body}",
             "type": "lineHeights"
           },
           "font-weight": {
@@ -1716,7 +1720,7 @@
             "type": "fontFamilies"
           },
           "line-height": {
-            "value": "{rhc.line-height.paragraph}",
+            "value": "{rhc.line-height.body}",
             "type": "lineHeights"
           },
           "font-weight": {
@@ -1724,7 +1728,7 @@
             "type": "fontWeights"
           },
           "font-size": {
-            "value": "{rhc.font-size.paragraph.intro}",
+            "value": "{rhc.font-size.body.intro}",
             "type": "fontSizes"
           },
           "color": {
@@ -1769,7 +1773,7 @@
           "type": "borderRadius"
         },
         "border-width": {
-          "value": "{rhc.border-width.m}",
+          "value": "{rhc.border-width.md}",
           "type": "borderWidth"
         }
       }
@@ -1779,11 +1783,11 @@
     "utrecht": {
       "breadcrumb-nav": {
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "link": {
@@ -1934,7 +1938,7 @@
           "type": "fontFamilies"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "font-weight": {
@@ -1942,7 +1946,7 @@
           "type": "fontWeights"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "padding-block-end": {
@@ -2379,7 +2383,7 @@
             "type": "color"
           },
           "border-width": {
-            "value": "{rhc.border-width.m}",
+            "value": "{rhc.border-width.md}",
             "type": "borderWidth"
           }
         },
@@ -2426,7 +2430,7 @@
           },
           "focus": {
             "border-width": {
-              "value": "{rhc.border-width.m}",
+              "value": "{rhc.border-width.md}",
               "type": "borderWidth"
             },
             "background-color": {
@@ -2560,7 +2564,7 @@
               "type": "color"
             },
             "border-width": {
-              "value": "{rhc.border-width.m}",
+              "value": "{rhc.border-width.md}",
               "type": "borderWidth"
             }
           }
@@ -2622,11 +2626,11 @@
     "utrecht": {
       "counter-badge": {
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "min-block-size": {
@@ -2843,7 +2847,7 @@
             "type": "spacing"
           },
           "line-height": {
-            "value": "{rhc.line-height.paragraph}",
+            "value": "{rhc.line-height.body}",
             "type": "lineHeights"
           }
         }
@@ -2950,7 +2954,7 @@
           "type": "fontFamilies"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "line-height": {
@@ -2990,7 +2994,7 @@
           "type": "fontFamilies"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "font-weight": {
@@ -3020,7 +3024,7 @@
           "type": "fontFamilies"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "font-weight": {
@@ -3042,11 +3046,11 @@
           "type": "color"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "font-family": {
@@ -3092,7 +3096,7 @@
           "type": "color"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "font-weight": {
@@ -3114,11 +3118,11 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.body.strong}",
+          "value": "{rhc.font-weight.heading}",
           "type": "fontWeights"
         },
         "line-height": {
-          "value": "{rhc.line-height.sm}",
+          "value": "{rhc.line-height.heading}",
           "type": "lineHeights"
         },
         "font-size": {
@@ -3144,11 +3148,11 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.body.strong}",
+          "value": "{rhc.font-weight.heading}",
           "type": "fontWeights"
         },
         "line-height": {
-          "value": "{rhc.line-height.sm}",
+          "value": "{rhc.line-height.heading}",
           "type": "lineHeights"
         },
         "font-size": {
@@ -3174,11 +3178,11 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.body.strong}",
+          "value": "{rhc.font-weight.heading}",
           "type": "fontWeights"
         },
         "line-height": {
-          "value": "{rhc.line-height.sm}",
+          "value": "{rhc.line-height.heading}",
           "type": "lineHeights"
         },
         "font-size": {
@@ -3204,11 +3208,11 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.body.strong}",
+          "value": "{rhc.font-weight.heading}",
           "type": "fontWeights"
         },
         "line-height": {
-          "value": "{rhc.line-height.sm}",
+          "value": "{rhc.line-height.heading}",
           "type": "lineHeights"
         },
         "font-size": {
@@ -3234,11 +3238,11 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{rhc.font-weight.body.strong}",
+          "value": "{rhc.font-weight.heading}",
           "type": "fontWeights"
         },
         "line-height": {
-          "value": "{rhc.line-height.sm}",
+          "value": "{rhc.line-height.heading}",
           "type": "lineHeights"
         },
         "font-size": {
@@ -3283,11 +3287,11 @@
             "type": "fontWeights"
           },
           "line-height": {
-            "value": "{rhc.line-height.paragraph}",
+            "value": "{rhc.line-height.body}",
             "type": "lineHeights"
           },
           "font-size": {
-            "value": "{rhc.font-size.paragraph.default}",
+            "value": "{rhc.font-size.body.default}",
             "type": "fontSizes"
           },
           "font-family": {
@@ -3461,11 +3465,11 @@
           "type": "fontWeights"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         }
       }
@@ -3777,11 +3781,11 @@
           "type": "fontWeights"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         }
       }
@@ -3801,7 +3805,7 @@
               "type": "spacing"
             },
             "size": {
-              "value": "{rhc.icon.functional.size}",
+              "value": "{rhc.size.icon.functional}",
               "type": "sizing"
             }
           },
@@ -4107,7 +4111,7 @@
           "type": "fontFamilies"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "font-weight": {
@@ -4115,7 +4119,7 @@
           "type": "fontWeights"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "margin-block-end": {
@@ -4132,7 +4136,7 @@
             "type": "color"
           },
           "font-size": {
-            "value": "{rhc.font-size.paragraph.intro}",
+            "value": "{rhc.font-size.body.intro}",
             "type": "fontSizes"
           },
           "font-weight": {
@@ -4140,7 +4144,7 @@
             "type": "fontWeights"
           },
           "line-height": {
-            "value": "{rhc.line-height.paragraph}",
+            "value": "{rhc.line-height.body}",
             "type": "lineHeights"
           }
         },
@@ -4150,7 +4154,7 @@
             "type": "color"
           },
           "font-size": {
-            "value": "{rhc.font-size.paragraph.default}",
+            "value": "{rhc.font-size.body.default}",
             "type": "fontSizes"
           },
           "font-weight": {
@@ -4158,7 +4162,7 @@
             "type": "fontWeights"
           },
           "line-height": {
-            "value": "{rhc.line-height.paragraph}",
+            "value": "{rhc.line-height.body}",
             "type": "lineHeights"
           }
         }
@@ -4224,7 +4228,7 @@
             "type": "color"
           },
           "border-width": {
-            "value": "{rhc.border-width.m}",
+            "value": "{rhc.border-width.md}",
             "type": "borderWidth"
           }
         },
@@ -4305,7 +4309,7 @@
               "type": "color"
             },
             "border-width": {
-              "value": "{rhc.border-width.m}",
+              "value": "{rhc.border-width.md}",
               "type": "borderWidth"
             }
           },
@@ -4428,7 +4432,7 @@
             "type": "color"
           },
           "border-width": {
-            "value": "{rhc.border-width.m}",
+            "value": "{rhc.border-width.md}",
             "type": "borderWidth"
           }
         },
@@ -4501,11 +4505,11 @@
           "type": "fontWeights"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "max-inline-size": {
@@ -4523,7 +4527,7 @@
           "type": "color"
         },
         "block-size": {
-          "value": "{rhc.border-width.m}",
+          "value": "{rhc.border-width.md}",
           "type": "sizing"
         },
         "margin-block-end": {
@@ -4542,7 +4546,7 @@
       "sidenav": {
         "link": {
           "line-height": {
-            "value": "{rhc.line-height.paragraph}",
+            "value": "{rhc.line-height.body}",
             "type": "lineHeights"
           },
           "icon": {
@@ -4556,7 +4560,7 @@
             }
           },
           "font-size": {
-            "value": "{rhc.font-size.paragraph.default}",
+            "value": "{rhc.font-size.body.default}",
             "type": "fontSizes"
           },
           "font-family": {
@@ -4652,11 +4656,11 @@
           "type": "fontFamilies"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "min-block-size": {
@@ -4697,7 +4701,7 @@
             "type": "borderStyle"
           },
           "border-width": {
-            "value": "{rhc.border-width.m}",
+            "value": "{rhc.border-width.md}",
             "type": "borderWidth"
           },
           "color": {
@@ -4728,7 +4732,7 @@
           "type": "color"
         },
         "border-width": {
-          "value": "{rhc.border-width.m}",
+          "value": "{rhc.border-width.md}",
           "type": "borderWidth"
         },
         "box-block-end-shadow": {
@@ -4757,11 +4761,11 @@
     "utrecht": {
       "status-badge": {
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "font-weight": {
@@ -4961,11 +4965,11 @@
           }
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "item-action": {
@@ -5012,7 +5016,7 @@
       "table": {
         "header-cell": {
           "line-height": {
-            "value": "{rhc.line-height.paragraph}",
+            "value": "{rhc.line-height.body}",
             "type": "lineHeights"
           },
           "color": {
@@ -5028,7 +5032,7 @@
             "type": "fontWeights"
           },
           "font-size": {
-            "value": "{rhc.font-size.paragraph.default}",
+            "value": "{rhc.font-size.body.default}",
             "type": "fontSizes"
           }
         },
@@ -5090,17 +5094,17 @@
             "type": "fontWeights"
           },
           "line-height": {
-            "value": "{rhc.line-height.paragraph}",
+            "value": "{rhc.line-height.body}",
             "type": "lineHeights"
           },
           "font-size": {
-            "value": "{rhc.font-size.paragraph.default}",
+            "value": "{rhc.font-size.body.default}",
             "type": "fontSizes"
           }
         },
         "header": {
           "border-block-end-width": {
-            "value": "{rhc.border-width.m}",
+            "value": "{rhc.border-width.md}",
             "type": "borderWidth"
           },
           "border-block-end-color": {
@@ -5146,7 +5150,7 @@
             "type": "fontWeights"
           },
           "font-size": {
-            "value": "{rhc.font-size.paragraph.default}",
+            "value": "{rhc.font-size.body.default}",
             "type": "fontSizes"
           },
           "color": {
@@ -5158,7 +5162,7 @@
             "type": "fontFamilies"
           },
           "line-height": {
-            "value": "{rhc.line-height.paragraph}",
+            "value": "{rhc.line-height.body}",
             "type": "lineHeights"
           }
         },
@@ -5350,7 +5354,7 @@
             "type": "color"
           },
           "border-width": {
-            "value": "{rhc.border-width.m}",
+            "value": "{rhc.border-width.md}",
             "type": "borderWidth"
           }
         },
@@ -5421,11 +5425,11 @@
           "type": "fontWeights"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         }
       }
@@ -5443,7 +5447,7 @@
           "type": "fontFamilies"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "font-weight": {
@@ -5451,7 +5455,7 @@
           "type": "fontWeights"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "max-inline-size": {
@@ -5520,7 +5524,7 @@
         },
         "focus": {
           "border-width": {
-            "value": "{rhc.border-width.m}",
+            "value": "{rhc.border-width.md}",
             "type": "borderWidth"
           },
           "background-color": {
@@ -5711,11 +5715,11 @@
           "type": "fontWeights"
         },
         "font-size": {
-          "value": "{rhc.font-size.paragraph.default}",
+          "value": "{rhc.font-size.body.default}",
           "type": "fontSizes"
         },
         "line-height": {
-          "value": "{rhc.line-height.paragraph}",
+          "value": "{rhc.line-height.body}",
           "type": "lineHeights"
         },
         "item": {

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -695,7 +695,7 @@
           "type": "fontWeights"
         },
         "semi-bold": {
-          "value": "550",
+          "value": "600",
           "type": "fontWeights"
         },
         "regular": {

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -1916,7 +1916,7 @@
           "type": "color"
         },
         "border-radius": {
-          "value": "5px",
+          "value": "{rhc.border-radius.md}",
           "type": "borderRadius"
         },
         "border-width": {
@@ -2044,7 +2044,7 @@
               "type": "color"
             },
             "color": {
-              "value": "{rhc.color.wit}",
+              "value": "{rhc.color.foreground.on-color}",
               "type": "color"
             }
           },
@@ -2057,7 +2057,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{rhc.color.wit}",
+            "value": "{rhc.color.foreground.on-color}",
             "type": "color"
           },
           "disabled": {
@@ -2084,7 +2084,7 @@
               "type": "color"
             },
             "color": {
-              "value": "{rhc.color.wit}",
+              "value": "{rhc.color.foreground.on-color}",
               "type": "color"
             }
           },
@@ -2111,7 +2111,7 @@
               "type": "color"
             },
             "color": {
-              "value": "{rhc.color.wit}",
+              "value": "{rhc.color.foreground.on-color}",
               "type": "color"
             }
           },
@@ -2120,7 +2120,7 @@
             "type": "fontSizes"
           },
           "line-height": {
-            "value": "1.875rem",
+            "value": "{rhc.line-height.body}",
             "type": "lineHeights"
           }
         },
@@ -2202,7 +2202,7 @@
             "type": "fontSizes"
           },
           "line-height": {
-            "value": "1.875rem",
+            "value": "{rhc.line-height.body}",
             "type": "lineHeights"
           }
         },
@@ -2293,7 +2293,7 @@
             }
           },
           "line-height": {
-            "value": "1.875rem",
+            "value": "{rhc.line-height.body}",
             "type": "lineHeights"
           }
         }

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -1056,7 +1056,7 @@
             "type": "fontWeights"
           },
           "normal": {
-            "value": "{rhc.font-weight.body.strong}",
+            "value": "{rhc.font-weight.regular}",
             "type": "fontWeights"
           }
         },


### PR DESCRIPTION
Nieuwe poging ipv [deze branch](https://github.com/nl-design-system/rijkshuisstijl-community/pull/627) die build errors heeft die ik niet opgelost krijg.

- de waarde van `rhc.color.foreground.subdued` aangepast naar lintblauw ipv grijs
- `rhc.color.foreground.default` is nu lintblauw en `rhc.color.foreground.lint` bestaat niet meer
-` rhc.font-weight.body.strong`, `rhc.font-weight.body.normal` en `rhc.font-weight.heading` tokens toegevoegd op de common laag
- De component font-weight tokens die eerder verwezen naar de brand tokens laten verwijzen naar de nieuwe common tokens op het logo na.
- `rhc.line-height.heading` toegevoegd. _(discussie voor later of die handig is: heading-level-5 wil je niet verwijzen naar 125% vermoed ik maar level 1 wel. Dit doen we nu alleen ook al ;) )_
- heading component font-weight tokens verwezen naar `rhc.line-height.heading`
- rhc.*.paragraph.* tokens hernoemt naar rhc.*.body.* 
- rhc.border-width.m hernoemd naar rhc.border-width.md
- rhc.color.foreground.onEmphases hernoemd naar rhc.color.foreground.on-color

Extra:
- Alle size tokens die px hadden aangepast naar rem
- brand token `font-weight.chosen-regular` verwijderd. (Hoe is die daar terecht gekomen? 🧐)
- Button component tokens verwezen naar commonlaag waar dat nog niet gebeurde, border en foreground Colors. 