### PR TITLE
feat(accordion): fixed icon span size and stopped center alignment when there is a lot of text in the accordion

### DIFF
--- a/packages/components-css/accordion/index.scss
+++ b/packages/components-css/accordion/index.scss
@@ -53,6 +53,8 @@
   --utrecht-button-padding-block-start: var(--utrecht-accordion-button-padding-block-start, inherit);
   --utrecht-button-padding-inline-end: var(--utrecht-accordion-button-padding-inline-end, inherit);
   --utrecht-button-padding-inline-start: var(--utrecht-accordion-button-padding-inline-start, inherit);
+
+  align-items: start;
 }
 
 .utrecht-accordion__button:focus-visible,
@@ -61,5 +63,10 @@
 }
 
 .utrecht-accordion__button-icon {
+  align-items: center;
+  block-size: var(--utrecht-accordion-button-icon-size);
+  display: flex;
   fill: var(--utrecht-accordion-button-color, inherit);
+  inline-size: var(--utrecht-accordion-button-icon-size);
+  margin-block: var(--utrecht-accordion-button-icon-margin-block);
 }

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -1322,8 +1322,8 @@
             "type": "spacing"
           },
           "icon": {
-            "margin-inline": {
-              "value": "{rhc.space.100}",
+            "margin-block": {
+              "value": "{rhc.space.50}",
               "type": "spacing"
             },
             "size": {


### PR DESCRIPTION
closes #697

Updated token: changed utrecht.accordion.button.icon.margin-inline to utrecht.accordion.button.icon.margin-block with value {rhc.space.50}