### PR TITLE
Feature/accordion (token renaming)

### DIFF
--- a/packages/components-css/accordion/index.scss
+++ b/packages/components-css/accordion/index.scss
@@ -6,53 +6,47 @@
 @import "../button/mixin";
 
 .utrecht-accordion {
-  color: var(--utrecht-accordion-color, inherit);
+  color: var(--rhc-accordion-color, inherit);
   display: flex;
   flex-direction: column;
   row-gap: var(--utrecht-accordion-row-gap, inherit);
 }
 
 .utrecht-accordion__header {
-  margin-block-end: var(--utrecht-accordion-header-margin-block-end, var(--utrecht-accordion-header-margin, inherit));
-  margin-block-start: var(
-    --utrecht-accordion-header-margin-block-start,
-    var(--utrecht-accordion-header-margin, inherit)
-  );
-  margin-inline-end: var(--utrecht-accordion-header-margin-inline-end, var(--utrecht-accordion-header-margin, inherit));
-  margin-inline-start: var(
-    --utrecht-accordion-header-margin-inline-start,
-    var(--utrecht-accordion-header-margin, inherit)
-  );
+  margin-block-end: var(--rhc-accordion-header-margin-block-end, var(--rhc-accordion-header-margin, inherit));
+  margin-block-start: var(--rhc-accordion-header-margin-block-start, var(--rhc-accordion-header-margin, inherit));
+  margin-inline-end: var(--rhc-accordion-header-margin-inline-end, var(--rhc-accordion-header-margin, inherit));
+  margin-inline-start: var(--rhc-accordion-header-margin-inline-start, var(--rhc-accordion-header-margin, inherit));
 }
 
 .utrecht-accordion__section {
   border-block-end-width: var(
-    --utrecht-accordion-section-border-block-end-width,
-    var(--utrecht-accordion-section-border-width, inherit)
+    --rhc-accordion-section-border-block-end-width,
+    var(--rhc-accordion-section-border-width, inherit)
   );
   border-block-start-width: var(
-    --utrecht-accordion-section-border-block-start-width,
-    var(--utrecht-accordion-section-border-width, inherit)
+    --rhc-accordion-section-border-block-start-width,
+    var(--rhc-accordion-section-border-width, inherit)
   );
-  border-color: var(--utrecht-accordion-section-border-color, inherit);
+  border-color: var(--rhc-accordion-section-border-color, inherit);
   border-inline-end-width: var(
-    --utrecht-accordion-section-border-inline-end-width,
-    var(--utrecht-accordion-section-border-width, inherit)
+    --rhc-accordion-section-border-inline-end-width,
+    var(--rhc-accordion-section-border-width, inherit)
   );
   border-inline-start-width: var(
-    --utrecht-accordion-section-border-inline-start-width,
-    var(--utrecht-accordion-section-border-width, inherit)
+    --rhc-accordion-section-border-inline-start-width,
+    var(--rhc-accordion-section-border-width, inherit)
   );
   border-style: solid;
 }
 
 .utrecht-accordion__button {
-  --_utrecht-button-appearance-font-weight: var(--utrecht-accordion-button-font-weight, inherit);
-  --utrecht-button-border-radius: var(--utrecht-accordion-border-radius, inherit);
-  --utrecht-button-padding-block-end: var(--utrecht-accordion-button-padding-block-end, inherit);
-  --utrecht-button-padding-block-start: var(--utrecht-accordion-button-padding-block-start, inherit);
-  --utrecht-button-padding-inline-end: var(--utrecht-accordion-button-padding-inline-end, inherit);
-  --utrecht-button-padding-inline-start: var(--utrecht-accordion-button-padding-inline-start, inherit);
+  --_utrecht-button-appearance-font-weight: var(--rhc-accordion-button-font-weight, inherit);
+  --utrecht-button-border-radius: var(--rhc-accordion-border-radius, inherit);
+  --utrecht-button-padding-block-end: var(--rhc-accordion-button-padding-block-end, inherit);
+  --utrecht-button-padding-block-start: var(--rhc-accordion-button-padding-block-start, inherit);
+  --utrecht-button-padding-inline-end: var(--rhc-accordion-button-padding-inline-end, inherit);
+  --utrecht-button-padding-inline-start: var(--rhc-accordion-button-padding-inline-start, inherit);
 
   align-items: start;
 }
@@ -68,5 +62,6 @@
   display: flex;
   fill: var(--utrecht-accordion-button-color, inherit);
   inline-size: var(--utrecht-accordion-button-icon-size);
-  margin-block: var(--utrecht-accordion-button-icon-margin-block);
+  justify-content: center;
+  margin-block: var(--rhc-accordion-button-icon-margin-block);
 }

--- a/packages/components-css/accordion/index.scss
+++ b/packages/components-css/accordion/index.scss
@@ -53,6 +53,8 @@
   --utrecht-button-padding-block-start: var(--utrecht-accordion-button-padding-block-start, inherit);
   --utrecht-button-padding-inline-end: var(--utrecht-accordion-button-padding-inline-end, inherit);
   --utrecht-button-padding-inline-start: var(--utrecht-accordion-button-padding-inline-start, inherit);
+
+  align-items: start;
 }
 
 .utrecht-accordion__button:focus-visible,
@@ -61,5 +63,10 @@
 }
 
 .utrecht-accordion__button-icon {
+  align-items: center;
+  block-size: var(--utrecht-accordion-button-icon-size);
+  display: flex;
   fill: var(--utrecht-accordion-button-color, inherit);
+  inline-size: var(--utrecht-accordion-button-icon-size);
+  margin-block: var(--utrecht-accordion-button-icon-margin-block);
 }

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -1248,19 +1248,57 @@
     }
   },
   "components/accordion": {
-    "utrecht": {
+    "rhc": {
       "accordion": {
-        "border-radius": {
-          "value": "0px",
-          "type": "borderRadius"
-        },
-        "color": {
-          "value": "{rhc.color.foreground.lint}",
-          "type": "color"
-        },
-        "row-gap": {
-          "value": "0",
-          "type": "spacing"
+        "button": {
+          "font-family": {
+            "value": "{rhc.font-family.primary}",
+            "type": "fontFamilies"
+          },
+          "font-size": {
+            "value": "{rhc.font-size.paragraph.default}",
+            "type": "fontSizes"
+          },
+          "font-weight": {
+            "value": "{rhc.font-weight.chosen-regular}",
+            "type": "fontWeights"
+          },
+          "line-height": {
+            "value": "{rhc.line-height.md}",
+            "type": "lineHeights"
+          },
+          "icon": {
+            "margin-block": {
+              "value": "{rhc.space.50}",
+              "type": "spacing"
+            }
+          },
+          "padding-block-end": {
+            "value": "{rhc.space.150}",
+            "type": "spacing"
+          },
+          "padding-block-start": {
+            "value": "{rhc.space.150}",
+            "type": "spacing"
+          },
+          "padding-inline-end": {
+            "value": "{rhc.space.200}",
+            "type": "spacing"
+          },
+          "padding-inline-start": {
+            "value": "{rhc.space.200}",
+            "type": "spacing"
+          },
+          "expanded": {
+            "background-color": {
+              "value": "{rhc.color.canvas}",
+              "type": "color"
+            },
+            "color": {
+              "value": "{rhc.color.foreground.lint}",
+              "type": "color"
+            }
+          }
         },
         "section": {
           "border-block-end-width": {
@@ -1276,6 +1314,24 @@
             "type": "color"
           }
         },
+        "header": {
+          "margin": {
+            "value": "0",
+            "type": "spacing"
+          }
+        },
+        "border-radius": {
+          "value": "0px",
+          "type": "borderRadius"
+        },
+        "color": {
+          "value": "{rhc.color.foreground.lint}",
+          "type": "color"
+        }
+      }
+    },
+    "utrecht": {
+      "accordion": {
         "panel": {
           "border-color": {
             "value": "{rhc.color.border.subdued}",
@@ -1302,50 +1358,16 @@
             "type": "spacing"
           }
         },
-        "header": {
-          "margin": {
-            "value": "0",
-            "type": "spacing"
-          }
-        },
         "button": {
-          "font-size": {
-            "value": "{rhc.font-size.paragraph.default}",
-            "type": "fontSizes"
-          },
-          "line-height": {
-            "value": "{rhc.line-height.md}",
-            "type": "lineHeights"
-          },
           "gap": {
             "value": "{rhc.space.100}",
             "type": "spacing"
           },
           "icon": {
-            "margin-block": {
-              "value": "{rhc.space.50}",
-              "type": "spacing"
-            },
             "size": {
               "value": "{rhc.size.icon.functional}",
               "type": "sizing"
             }
-          },
-          "padding-block-end": {
-            "value": "{rhc.space.150}",
-            "type": "spacing"
-          },
-          "padding-block-start": {
-            "value": "{rhc.space.150}",
-            "type": "spacing"
-          },
-          "padding-inline-end": {
-            "value": "{rhc.space.200}",
-            "type": "spacing"
-          },
-          "padding-inline-start": {
-            "value": "{rhc.space.200}",
-            "type": "spacing"
           },
           "hover": {
             "background-color": {
@@ -1354,16 +1376,6 @@
             },
             "border-color": {
               "value": "{rhc.color.border.subdued}",
-              "type": "color"
-            },
-            "color": {
-              "value": "{rhc.color.foreground.lint}",
-              "type": "color"
-            }
-          },
-          "expanded": {
-            "background-color": {
-              "value": "{rhc.color.canvas}",
               "type": "color"
             },
             "color": {
@@ -1413,15 +1425,11 @@
             "color": {
               "value": "{rhc.color.foreground.lint}",
               "type": "color"
+            },
+            "row-gap": {
+              "value": "0",
+              "type": "spacing"
             }
-          },
-          "font-family": {
-            "value": "{rhc.font-family.primary}",
-            "type": "fontFamilies"
-          },
-          "font-weight": {
-            "value": "{rhc.font-weight.chosen-regular}",
-            "type": "fontWeights"
           }
         }
       }

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -1322,8 +1322,8 @@
             "type": "spacing"
           },
           "icon": {
-            "margin-inline": {
-              "value": "{rhc.space.100}",
+            "margin-block": {
+              "value": "{rhc.space.50}",
               "type": "spacing"
             },
             "size": {


### PR DESCRIPTION
Updated tokens:

1. changed utrecht.accordion.button.icon.margin-inline to utrecht.accordion.button.icon.margin-block with value {rhc.space.50}
2. utrecht.accordion.color -> rhc.accordion.color
3. utrecht.accordion.row-gap -> rhc.accordion.row-gap
4. utrecht.accordion.header.margin-block-end -> rhc.accordion.header.margin-block-end
5. utrecht.accordion.header.margin-block-start -> rhc.accordion.header.margin-block-start
6. utrecht.accordion.header.margin-inline-end -> rhc.accordion.header.margin-inline-end
7. utrecht.accordion.header.margin-inline-start -> rhc.accordion.header.margin-inline-start
8. utrecht.accordion.section.border-block-end-width -> rhc.accordion.section.border-block-end-width
9. utrecht.accordion.section.border-block-width -> rhc.accordion.section.border-block-width
10. utrecht.accordion.section.border-color -> rhc.accordion.section.border-color
11. utrecht.accordion.button.font-weight -> rhc.accordion.button.font-weight
12. utrecht.accordion.border-radius -> rhc.accordion.border-radius
13. utrecht.accordion.button.padding-block-end -> rhc.accordion.button.padding-block-end
14. utrecht.accordion.button.padding-block-start -> rhc.accordion.button.padding-block-start
15. utrecht.accordion.button.padding-inline-end -> rhc.accordion.button.padding-inline-end
16. utrecht.accordion.button.padding-inline-start -> rhc.accordion.button.padding-inline-start