### PR TITLE
fix: spacing between label and description

### DIFF
--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -3117,6 +3117,10 @@
           "value": "{rhc.line-height.md}",
           "type": "lineHeights"
         },
+        "margin-block-start": {
+          "value": "-{rhc.space.100}",
+          "type": "spacing"
+        },
         "margin-block-end": {
           "value": "{rhc.space.100}",
           "type": "spacing"


### PR DESCRIPTION
Added a negative margin-block-start on the description 

closes #696 