### PR TITLE
refactor: simplify rhc-page-footer using ColumnLayout

### DIFF
--- a/packages/components-css/footer/index.scss
+++ b/packages/components-css/footer/index.scss
@@ -3,35 +3,27 @@
  * Copyright (c) 2021 Community for NL Design System
  */
 .rhc-footer {
-  background-color: var(--utrecht-page-footer-background-color);
-  color: var(--utrecht-page-footer-color);
+  --utrecht-space-around: 1;
+  --utrecht-link-hover-text-decoration: underline;
+  --_utrecht-link-state-text-decoration-color: currentColor;
+  --utrecht-column-layout-column-gap: var(--rhc-page-footer-column-gap);
+  --utrecht-column-layout-column-width: var(--rhc-page-footer-column-width);
+  --utrecht-heading-1-color: currentColor;
+  --utrecht-heading-2-color: currentColor;
+  --utrecht-heading-3-color: currentColor;
+  --utrecht-heading-4-color: currentColor;
+  --utrecht-heading-5-color: currentColor;
+  --utrecht-heading-6-color: currentColor;
+
+  column-gap: var(--rhc-page-footer-column-gap);
   display: flex;
   flex-direction: row;
-  gap: var(--utrecht-page-footer-gap);
-  justify-content: flex-start;
-  padding-block-end: var(--utrecht-page-footer-padding-block-end);
-  padding-block-start: var(--utrecht-page-footer-padding-block-start);
-  padding-inline-end: var(--utrecht-page-footer-padding-inline-end);
-  padding-inline-start: var(--utrecht-page-footer-padding-inline-start);
-  @media (width <= 768px) {
-    flex-direction: column;
-  }
 }
 
-.rhc-footer__title {
-  color: var(--utrecht-page-footer-color) !important;
+.rhc-page-footer__section {
+  break-inside: avoid;
 }
 
-.rhc-footer__column--title {
-  --utrecht-space-around: 1;
-
-  color: var(--utrecht-page-footer-color) !important;
-  margin-block-end: var(--utrecht-page-footer-column-title-margin-block-end);
-}
-
-.rhc-footer__column {
-  --utrecht-link-hover-text-decoration: underline;
-  --_utrecht-link-state-text-decoration-color: --utrecht-page-footer-color;
-
+.rhc-footer > * {
   flex: 1;
 }

--- a/packages/components-react/src/Footer.tsx
+++ b/packages/components-react/src/Footer.tsx
@@ -1,4 +1,4 @@
-import { PageFooterProps, PageFooter as UtrechtPageFooter } from '@utrecht/component-library-react';
+import { ColumnLayout, PageFooterProps, PageFooter as UtrechtPageFooter } from '@utrecht/component-library-react';
 import clsx from 'clsx';
 import { ForwardedRef, forwardRef, PropsWithChildren, ReactNode } from 'react';
 import { Heading } from './Heading';
@@ -23,27 +23,27 @@ export const Footer = forwardRef(
   ) => (
     <UtrechtPageFooter {...restProps} className={clsx('rhc-footer', className)} ref={ref}>
       {heading && (
-        <div className="rhc-footer__column">
-          <Heading className="rhc-footer__title" level={headingLevel}>
-            {heading}
-          </Heading>
-        </div>
+        <Heading className="rhc-footer__title" level={headingLevel}>
+          {heading}
+        </Heading>
       )}
 
-      {columns &&
-        columns.map((column, index) => (
-          <div className="rhc-footer__column" key={index}>
-            <Heading
-              className="rhc-footer__column--title"
-              level={headingLevel >= MAX_HEADING_LEVEL ? MAX_HEADING_LEVEL : headingLevel + 1}
-            >
-              {column.heading}
-            </Heading>
-            {column.children}
-          </div>
-        ))}
+      <ColumnLayout>
+        {columns &&
+          columns.map((column, index) => (
+            <div className="rhc-page-footer__section" key={index}>
+              <Heading
+                className="rhc-footer__column--title"
+                level={headingLevel >= MAX_HEADING_LEVEL ? MAX_HEADING_LEVEL : headingLevel + 1}
+              >
+                {column.heading}
+              </Heading>
+              {column.children}
+            </div>
+          ))}
 
-      {children}
+        {children}
+      </ColumnLayout>
     </UtrechtPageFooter>
   ),
 );

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -3020,42 +3020,48 @@
   },
   "components/footer": {
     "utrecht": {
-      "page": {
-        "footer": {
-          "background-color": {
-            "value": "{rhc.color.lintblauw.500}",
-            "type": "color"
-          },
-          "color": {
-            "value": "{rhc.color.foreground.onEmphasis}",
-            "type": "color"
-          },
-          "padding-block-start": {
-            "value": "{rhc.space.600}",
-            "type": "spacing"
-          },
-          "padding-block-end": {
-            "value": "{rhc.space.600}",
-            "type": "spacing"
-          },
-          "padding-inline-start": {
-            "value": "80px",
-            "type": "spacing"
-          },
-          "padding-inline-end": {
-            "value": "80px",
-            "type": "spacing"
-          },
-          "gap": {
-            "value": "{rhc.space.300}",
-            "type": "spacing"
-          },
-          "column": {
-            "title": {
-              "margin-block-end": {
-                "value": "{rhc.space.150}",
-                "type": "spacing"
-              }
+      "page-footer": {
+        "background-color": {
+          "value": "{rhc.color.lintblauw.500}",
+          "type": "color"
+        },
+        "color": {
+          "value": "{rhc.color.foreground.onEmphasis}",
+          "type": "color"
+        },
+        "padding-block-start": {
+          "value": "{rhc.space.600}",
+          "type": "spacing"
+        },
+        "padding-block-end": {
+          "value": "{rhc.space.600}",
+          "type": "spacing"
+        },
+        "padding-inline-start": {
+          "value": "80px",
+          "type": "spacing"
+        },
+        "padding-inline-end": {
+          "value": "80px",
+          "type": "spacing"
+        }
+      }
+    },
+    "rhc": {
+      "page-footer": {
+        "column-gap": {
+          "value": "{rhc.space.300}",
+          "type": "spacing"
+        },
+        "column-width": {
+          "value": "200px",
+          "type": "sizing"
+        },
+        "column": {
+          "title": {
+            "margin-block-end": {
+              "value": "{rhc.space.150}",
+              "type": "spacing"
             }
           }
         }


### PR DESCRIPTION
Ik had het er met @AlineNap over dat de page footer misschien met minder design tokens en ColumnLayout geïmplementeerd kan worden. Deze PR is nog niet volledig of perfect, maar het laat zien hoe het zou kunnen werken. Laten we tijdens de Rijkshuisstijl Community refinement eens bespreken of iemand deze PR van mij wil overnemen.