### PR TITLE
Feature/link-list-card (added feedback points)

### DIFF
--- a/packages/components-css/link-list-card/index.scss
+++ b/packages/components-css/link-list-card/index.scss
@@ -1,4 +1,4 @@
-.rhc-link-list__card {
+.rhc-link-list-card {
   background-color: var(--rhc-link-list-card-background-color);
   display: flex;
   flex-direction: column;

--- a/packages/components-react/src/LinkListCard.tsx
+++ b/packages/components-react/src/LinkListCard.tsx
@@ -1,16 +1,17 @@
-import { forwardRef, HTMLAttributes } from 'react';
+import clsx from 'clsx';
+import { forwardRef, HTMLAttributes, ReactNode } from 'react';
 import { Heading } from './Heading';
 import { LinkList } from './LinkList';
 
 export interface LinkListCardProps extends HTMLAttributes<HTMLDivElement> {
   headingLevel: number;
-  heading: string;
+  heading: ReactNode;
 }
 
 export const LinkListCard = forwardRef<HTMLDivElement, LinkListCardProps>(
-  ({ children, headingLevel, heading }, ref) => {
+  ({ children, className, headingLevel, heading }, ref) => {
     return (
-      <div className="rhc-link-list__card" ref={ref}>
+      <div className={clsx('rhc-link-list-card', className)} ref={ref}>
         <Heading level={headingLevel}>{heading}</Heading>
         <LinkList>{children}</LinkList>
       </div>

--- a/packages/storybook/src/community/link-list-card.md
+++ b/packages/storybook/src/community/link-list-card.md
@@ -9,7 +9,7 @@ De **LinkListCard** component biedt een manier om een **card** weer te geven met
 - **`headingLevel`** (`number`)
   Dit bepaalt het niveau van de heading, vergelijkbaar met HTML heading-tags
 
-- **`headingText`** (`string`)
+- **`heading`** (`string`)
   De tekst die weergegeven wordt binnen de heading.
 
 LinkListCard-component bestaat uit de volgende subcomponenten:

--- a/packages/storybook/src/community/link-list-card.md
+++ b/packages/storybook/src/community/link-list-card.md
@@ -4,7 +4,7 @@
 
 [NL design system](https://www.nldesignsystem.nl/alert/) | [Figma](https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=1195-4201&t=n1djYpmvDCKmAEUi-0) | [GitHub](https://github.com/nl-design-system/rijkshuisstijl-community/issues/472)
 
-De **LinkListCard** component biedt een manier om een **card** weer te geven met een heading en een collectie van links. Dit component accepteert twee verschillende props: `headingLevel`, `headingText`
+De **LinkListCard** component biedt een manier om een **card** weer te geven met een heading en een collectie van links. Dit component accepteert twee verschillende props: `headingLevel`, `heading`
 
 - **`headingLevel`** (`number`)
   Dit bepaalt het niveau van de heading, vergelijkbaar met HTML heading-tags


### PR DESCRIPTION
Feedback van Robbert

- het is handig als je `clsx` gebruikt zodat je ook nog eigen class names kan toevoegen:
  - bijv: `<LinkListCard className="large"/>`
  - voorbeeld implementatie: https://github.com/nl-design-system/utrecht/blob/main/packages/component-library-react/src/Document.tsx#L13
- `rhc-link-list__card` is niet een logische bem class name. `__element` is bedoeld voor een onderdeel van een groter component, terwijl deze component een wrapper is. `rhc-link-list-card` is beter. Zie https://getbem.com
- `heading: string;` staat geen rich text toe zoals `<sub>` voor H<sub>2</sub>O. Je kunt beter `ReactNode` als type gebruiken.
- in de documentatie schrijf je over `headingText`, terwijl de property `heading` heet.