### PR TITLE
npm: Set publischConfig to public for components-css

### DIFF
--- a/packages/components-css/package.json
+++ b/packages/components-css/package.json
@@ -9,7 +9,7 @@
   ],
   "private": false,
   "publishConfig": {
-    "access": "restricted",
+    "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
   "repository": {


### PR DESCRIPTION
component-css packages is nodig om components-react packages te gebruiken