### PR TITLE
radio group

### DIFF
--- a/apps/rhc-templates/src/app/form/page.tsx
+++ b/apps/rhc-templates/src/app/form/page.tsx
@@ -98,11 +98,11 @@ export default function Form() {
                 <FormFieldTextarea label="Stel hier uw vraag" rows={6} cols={40}></FormFieldTextarea>
                 <Fieldset>
                   <FieldsetLegend>Label</FieldsetLegend>
-                  <div>
-                    <FormFieldRadioOption label="Label" />
-                    <FormFieldRadioOption label="Label" />
-                    <FormFieldRadioOption label="Label" />
-                    <FormFieldRadioOption label="Label" />
+                  <div className="rhc-radio-group">
+                    <FormFieldRadioOption name="name" label="Label" />
+                    <FormFieldRadioOption name="name" label="Label" />
+                    <FormFieldRadioOption name="name" label="Label" />
+                    <FormFieldRadioOption name="name" label="Label" />
                   </div>
                 </Fieldset>
                 {/*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,10 @@ importers:
         specifier: 5.5.3
         version: 5.5.3
 
+  apps/rhc-templates/dist: {}
+
+  apps/rhc-templates/dist/types: {}
+
   apps/rvs.rivm.nl:
     dependencies:
       next:


### PR DESCRIPTION
#[#763](https://github.com/nl-design-system/rijkshuisstijl-community/issues/763)

- Radio buttons op de [form pagina](https://rijkshuisstijl-community-templates.vercel.app/form) hebben nu een name property, waardoor je er maar één kan selecteren.
- De styling van `rhc-radio-group` word nu toegepast.