### PR TITLE
Je kan nu de ButtonLink focus state zien in de template

### DIFF
--- a/apps/rhc-templates/src/app/page.tsx
+++ b/apps/rhc-templates/src/app/page.tsx
@@ -143,7 +143,7 @@ export default function Page() {
                       </svg>
                     </Icon>
                   </Button>
-                  <ButtonLink appearance="secondary-action-button" external={true}>
+                  <ButtonLink appearance="secondary-action-button" external={true} href="#">
                     E-mail
                     <Icon>
                       <svg
@@ -163,7 +163,7 @@ export default function Page() {
                       </svg>
                     </Icon>
                   </ButtonLink>
-                  <ButtonLink appearance="secondary-action-button" external={true}>
+                  <ButtonLink appearance="secondary-action-button" external={true} href="#">
                     Twitter
                     <Icon>
                       <svg
@@ -183,7 +183,7 @@ export default function Page() {
                       </svg>
                     </Icon>
                   </ButtonLink>
-                  <ButtonLink appearance="secondary-action-button" external={true}>
+                  <ButtonLink appearance="secondary-action-button" external={true} href="#">
                     LinkedIn
                     <Icon>
                       <svg


### PR DESCRIPTION
De ButtonLink componenten in de template hadden geen href, waardoor je de focus state niet kon zien.