### PR TITLE
Removed Utrecht icon from template

### DIFF
--- a/apps/rhc-templates/src/app/details/page.tsx
+++ b/apps/rhc-templates/src/app/details/page.tsx
@@ -14,8 +14,8 @@ import {
   LinkList,
   LinkListLink,
   PageHeader,
+  Icon,
 } from '@rijkshuisstijl-community/components-react';
-import { UtrechtIconChevronRight } from '@utrecht/web-component-library-react';
 import { RichText } from '@utrecht/component-library-react/dist/css-module';
 
 export default function Details() {
@@ -105,25 +105,25 @@ export default function Details() {
             heading: 'Service',
             children: [
               <LinkList key="1">
-                <LinkListLink href="#" icon={<UtrechtIconChevronRight />}>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
                   Contact
                 </LinkListLink>
-                <LinkListLink href="#" icon={<UtrechtIconChevronRight />}>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
                   Abonneren
                 </LinkListLink>
-                <LinkListLink href="#" icon={<UtrechtIconChevronRight />}>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
                   RSS
                 </LinkListLink>
-                <LinkListLink href="#" icon={<UtrechtIconChevronRight />}>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
                   Vacatures
                 </LinkListLink>
-                <LinkListLink href="#" icon={<UtrechtIconChevronRight />}>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
                   Sitemap
                 </LinkListLink>
-                <LinkListLink href="#" icon={<UtrechtIconChevronRight />}>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
                   Help
                 </LinkListLink>
-                <LinkListLink href="#" icon={<UtrechtIconChevronRight />}>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
                   Archief
                 </LinkListLink>
               </LinkList>,
@@ -133,28 +133,28 @@ export default function Details() {
             heading: 'Over deze site',
             children: (
               <LinkList key="2">
-                <LinkListLink href="#" icon={<UtrechtIconChevronRight />}>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
                   Over Rijksoverheid.nl
                 </LinkListLink>
-                <LinkListLink href="#" icon={<UtrechtIconChevronRight />}>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
                   Wetten en regelingen
                 </LinkListLink>
-                <LinkListLink href="#" icon={<UtrechtIconChevronRight />}>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
                   Copyright
                 </LinkListLink>
-                <LinkListLink href="#" icon={<UtrechtIconChevronRight />}>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
                   Privacy
                 </LinkListLink>
-                <LinkListLink href="#" icon={<UtrechtIconChevronRight />}>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
                   Cookies
                 </LinkListLink>
-                <LinkListLink href="#" icon={<UtrechtIconChevronRight />}>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
                   Toegankelijkheid
                 </LinkListLink>
-                <LinkListLink href="#" icon={<UtrechtIconChevronRight />}>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
                   Open data
                 </LinkListLink>
-                <LinkListLink href="#" icon={<UtrechtIconChevronRight />}>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
                   Kwetsbaarheid melden
                 </LinkListLink>
               </LinkList>


### PR DESCRIPTION
Op de details template pagina werd nog de UtrechtIcon gebruikt ipv de rhc community versie