### PR TITLE
FIX: icon infront of link is now correctly aligned with label

### DIFF
--- a/packages/components-css/link-list/index.scss
+++ b/packages/components-css/link-list/index.scss
@@ -6,4 +6,6 @@
 .utrecht-link-list__link {
   --utrecht-link-icon-inset-block-start: var(--utrecht-link-list-icon-inset-block-start, inherit);
   --utrecht-link-column-gap: var(--utrecht-link-list-item-column-gap, inherit);
+
+  align-items: flex-start;
 }


### PR DESCRIPTION
#478 