### PR TITLE
chore(pipelines): disabled dependabot grouping since multiple dependencies don't follow patch-minor-major versioning standards

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    groups:
-      patch-and-minor-dependencies:
-        applies-to: "version-updates"
-        update-types:
-          - "patch"
-          - "minor"
     ignore:
       - dependency-name: "@types/node"
         update-types:


### PR DESCRIPTION
Idee is om het later te groeperen als we een beter beeld hebben van welke packages zich niet aan de regels houden betreft breaking changes in patch/minor versies, dan houden we die buiten deze groep