### PR TITLE
Refactor/answer-side-nav-design-review #651

### DIFF
--- a/packages/components-css/src/side-nav/index.scss
+++ b/packages/components-css/src/side-nav/index.scss
@@ -39,8 +39,10 @@
       text-decoration: var(--rhc-sidenav-link-focus-text-decoration);
     }
     &:focus-visible {
-      border-color: var(--rhc-color-focus-border-color);
-      border-width: var(--rhc-border-width-m);
+      border-color: var(--rhc-sidenav-link-focus-border-color);
+      border-radius: var(--rhc-sidenav-link-focus-border-radius);
+      border-style: var(--rhc-sidenav-link-focus-border-style);
+      border-width: var(--rhc-sidenav-link-focus-border-width);
     }
     &:hover {
       color: var(--rhc-sidenav-link-hover-color);

--- a/packages/components-react/src/SideNav.test.tsx
+++ b/packages/components-react/src/SideNav.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { createRef } from 'react';
 import { SideNav } from './SideNav';
 
 describe('SideNav', () => {
@@ -15,9 +16,9 @@ describe('SideNav', () => {
   });
 
   it('forwards ref correctly', () => {
-    render(<SideNav data-testid="test-id" />);
-
-    expect(screen.getByTestId('test-id')).toBeInstanceOf(HTMLElement);
+    const ref = createRef<HTMLElement>();
+    render(<SideNav ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLElement);
   });
   it('applies custom class name', () => {
     const testClassName = 'test-class';

--- a/packages/components-react/src/SideNav.test.tsx
+++ b/packages/components-react/src/SideNav.test.tsx
@@ -15,14 +15,14 @@ describe('SideNav', () => {
   });
 
   it('forwards ref correctly', () => {
-    render(<SideNav />);
+    render(<SideNav data-testid="test-id" />);
 
-    expect(screen.getByRole('navigation')).toBeInstanceOf(HTMLElement);
+    expect(screen.getByTestId('test-id')).toBeInstanceOf(HTMLElement);
   });
   it('applies custom class name', () => {
     const testClassName = 'test-class';
-    render(<SideNav className={testClassName} />);
+    render(<SideNav className={testClassName} data-testid="test-id" />);
 
-    expect(screen.getByRole('navigation')).toHaveClass(testClassName);
+    expect(screen.getByTestId('test-id')).toHaveClass(testClassName);
   });
 });

--- a/packages/components-react/src/SideNav.tsx
+++ b/packages/components-react/src/SideNav.tsx
@@ -5,7 +5,7 @@ export interface SideNavProps extends HTMLAttributes<HTMLElement> {}
 
 export const SideNav = forwardRef<HTMLElement, SideNavProps>(({ className, children, ...restProps }, ref) => {
   return (
-    <aside className={clsx('rhc-side-nav', className)} ref={ref} role="navigation" {...restProps}>
+    <aside className={clsx('rhc-side-nav', className)} ref={ref} {...restProps}>
       {children}
     </aside>
   );

--- a/packages/components-react/src/SideNavItem.test.tsx
+++ b/packages/components-react/src/SideNavItem.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { createRef } from 'react';
 import { SideNavItem } from './SideNavItem';
 
 describe('SideNaveItem', () => {
@@ -15,7 +16,7 @@ describe('SideNaveItem', () => {
   });
 
   it('forwards ref correctly', () => {
-    const ref = { current: null };
+    const ref = createRef<HTMLLIElement>();
     render(<SideNavItem ref={ref} />);
 
     expect(ref.current).toBeInstanceOf(HTMLLIElement);

--- a/packages/components-react/src/SideNavLink.test.tsx
+++ b/packages/components-react/src/SideNavLink.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { createRef } from 'react';
 import { SideNavLink } from './SideNavLink';
 
 describe('SideNavLink', () => {
@@ -11,9 +12,10 @@ describe('SideNavLink', () => {
   });
 
   it('forwards ref correctly', () => {
-    render(<SideNavLink />);
+    const ref = createRef<HTMLAnchorElement>();
+    render(<SideNavLink ref={ref} />);
 
-    expect(screen.getByRole('link')).toBeInstanceOf(HTMLAnchorElement);
+    expect(ref.current).toBeInstanceOf(HTMLAnchorElement);
   });
 
   it('applies custom class name', () => {

--- a/packages/storybook/src/community/side-nav-link.stories.tsx
+++ b/packages/storybook/src/community/side-nav-link.stories.tsx
@@ -25,9 +25,17 @@ const meta = {
       },
     },
   },
+  args: {
+    children: 'Label',
+    icon: 'activiteit',
+  },
+  render: (args) => {
+    return <SideNavLink {...args} />;
+  },
+
   parameters: {
     status: {
-      type: 'UNSTABLE',
+      type: 'STABLE',
     },
     docs: {
       description: {
@@ -42,97 +50,73 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     children: 'Mijn gegevens',
+    icon: 'user',
   },
 };
 
-export const Current: Story = {
-  args: {
-    children: 'Label',
-    current: true,
-  },
-};
 export const Hover: Story = {
-  args: {
-    children: 'Label',
-  },
   parameters: {
     pseudo: { hover: true },
   },
 };
 export const Focus: Story = {
-  args: {
-    children: 'Label',
-  },
   parameters: {
     pseudo: { focus: true },
   },
 };
 export const FocusVisible: Story = {
-  args: {
-    children: 'Label',
-  },
   parameters: {
     pseudo: { focusVisible: true },
   },
 };
 export const Active: Story = {
-  args: {
-    children: 'Label',
-  },
   parameters: {
     pseudo: { active: true },
   },
 };
 
-export const WithIcon: Story = {
+export const Current: Story = {
   args: {
-    children: 'Label',
-    icon: 'activiteit',
+    current: true,
   },
 };
 
 export const CurrentAndHover: Story = {
   args: {
-    children: 'Label',
     current: true,
-    icon: 'activiteit',
   },
   parameters: {
     pseudo: { hover: true },
   },
 };
 
+export const CurrentAndActive: Story = {
+  args: {
+    current: true,
+  },
+  parameters: {
+    pseudo: { active: true },
+  },
+};
 export const CurrentAndFocus: Story = {
   args: {
-    children: 'Label',
     current: true,
-    icon: 'activiteit',
   },
   parameters: {
     pseudo: { focus: true },
   },
 };
-
 export const CurrentAndFocusVisible: Story = {
   args: {
-    children: 'Label',
     current: true,
-    icon: 'activiteit',
   },
   parameters: {
-    pseudo: {
-      focusVisible: true,
-    },
+    pseudo: { focusVisible: true, focus: true },
   },
 };
 
-export const CurrentAndActive: Story = {
+export const WithoutIcon: Story = {
   args: {
-    children: 'Label',
-    current: true,
-    icon: 'activiteit',
-  },
-  parameters: {
-    pseudo: { active: true },
+    icon: undefined,
   },
 };

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -5567,6 +5567,22 @@
             }
           },
           "focus": {
+            "border-radius": {
+              "value": "{rhc.border-radius.md}",
+              "type": "borderRadius"
+            },
+            "border-width": {
+              "value": "{rhc.border-width.m}",
+              "type": "borderWidth"
+            },
+            "border-style": {
+              "value": "solid",
+              "type": "borderStyle"
+            },
+            "border-color": {
+              "value": "{rhc.color.lintblauw.500}",
+              "type": "color"
+            },
             "background-color": {
               "value": "none",
               "type": "color"


### PR DESCRIPTION
antwoord de design review taak #651 per deze [comment](https://github.com/nl-design-system/rijkshuisstijl-community/issues/651#issuecomment-2444369137)

- Reorder de stories
- Voeg een icoon toe aan alle stories
- Zorg ervoor dat `focus-visible` werkt
- Het laatste probleem: "Wanneer je naar een specifieke staat gaat, wordt deze toegepast op alle stories in het default tab. " Dit is een bug in de [plugin](https://www.npmjs.com/package/storybook-addon-pseudo-states). k heb geen oplossing kunnen vinden. Het heeft mogelijk meer onderzoek nodig, maar dit is niet gerelateerd aan de design review. Het heeft een apart taak en PR nodig als er ooit een oplossing wordt gevonden.