### PR TITLE
build: add `dist/tokens.json` to design tokens package

### DIFF
--- a/proprietary/design-tokens/style-dictionary.config.json
+++ b/proprietary/design-tokens/style-dictionary.config.json
@@ -20,6 +20,10 @@
       "buildPath": "dist/",
       "files": [
         {
+          "destination": "tokens.json",
+          "format": "json"
+        },
+        {
           "destination": "index.tokens.json",
           "format": "json/nested"
         },


### PR DESCRIPTION
We zijn de tokens aan het gebruiken voor developer.overheid.nl, maar we hebben een extra formaat nodig 

![Photo on 11-12-2024 at 12 04 #2](https://github.com/user-attachments/assets/96404e05-9ce2-45b5-a28e-29649ac40875)
