### PR TITLE
feat(alert): fixed vertical alignment when there is no heading and updated tokens

### DIFF
--- a/packages/components-css/src/alert/index.scss
+++ b/packages/components-css/src/alert/index.scss
@@ -3,15 +3,24 @@
  * Copyright (c) 2021 Community for NL Design System
  */
 
-.rhc-alert__container {
+.rhc-alert {
+  --utrecht-heading-1-line-height: var(--utrecht-alert-heading-line-height);
+  --utrecht-heading-2-line-height: var(--utrecht-alert-heading-line-height);
+  --utrecht-heading-3-line-height: var(--utrecht-alert-heading-line-height);
+  --utrecht-heading-4-line-height: var(--utrecht-alert-heading-line-height);
+  --utrecht-heading-5-line-height: var(--utrecht-alert-heading-line-height);
+  --utrecht-icon-inset-block-start: var(--utrecht-alert-icon-inset-block-start);
+  --utrecht-paragraph-line-height: var(--utrecht-alert-message-line-height);
+}
+
+.utrecht-alert__message {
+  column-gap: var(--utrecht-alert-message-column-gap);
   display: flex;
 }
 
 .rhc-alert__icon-container {
   inline-size: var(--utrecht-alert-icon-size);
-  inset-block-start: var(--utrecht-alert-icon-inset-block-start);
   min-inline-size: var(--utrecht-alert-icon-size);
-  padding-inline-end: var(--rhc-space-100);
   &--ok {
     color: var(--rhc-color-feedback-success-default);
   }

--- a/packages/components-react/src/Alert.tsx
+++ b/packages/components-react/src/Alert.tsx
@@ -41,8 +41,8 @@ export const Alert = forwardRef(
             {heading}
           </Heading>
           <Paragraph>{textContent}</Paragraph>
+          {children}
         </div>
-        {children}
       </UtrechtAlert>
     );
   },

--- a/packages/components-react/src/Alert.tsx
+++ b/packages/components-react/src/Alert.tsx
@@ -15,34 +15,32 @@ export const Alert = forwardRef(
     ref: ForwardedRef<HTMLDivElement>,
   ) => {
     return (
-      <UtrechtAlert ref={ref} type={type} {...restProps}>
-        <div className="rhc-alert__container">
-          <div
-            className={clsx('rhc-alert__icon-container', {
-              'rhc-alert__icon-container--ok': type === 'ok',
-              'rhc-alert__icon-container--error': type === 'error',
-              'rhc-alert__icon-container--warning': type === 'warning',
-              'rhc-alert__icon-container--info': type === 'info',
-            })}
-          >
-            <Icon
-              icon={
-                type === 'info'
-                  ? 'info-circle'
-                  : type === 'ok'
-                    ? 'circle-check'
-                    : type === 'warning'
-                      ? 'let-op'
-                      : 'alert-circle'
-              }
-            />
-          </div>
-          <div>
-            <Heading appearance="utrecht-heading-5" level={headingLevel || 3}>
-              {heading}
-            </Heading>
-            <Paragraph>{textContent}</Paragraph>
-          </div>
+      <UtrechtAlert className="rhc-alert" ref={ref} type={type} {...restProps}>
+        <div
+          className={clsx('rhc-alert__icon-container', {
+            'rhc-alert__icon-container--ok': type === 'ok',
+            'rhc-alert__icon-container--error': type === 'error',
+            'rhc-alert__icon-container--warning': type === 'warning',
+            'rhc-alert__icon-container--info': type === 'info',
+          })}
+        >
+          <Icon
+            icon={
+              type === 'info'
+                ? 'info-circle'
+                : type === 'ok'
+                  ? 'circle-check'
+                  : type === 'warning'
+                    ? 'let-op'
+                    : 'alert-circle'
+            }
+          />
+        </div>
+        <div>
+          <Heading appearance="utrecht-heading-5" level={headingLevel || 3}>
+            {heading}
+          </Heading>
+          <Paragraph>{textContent}</Paragraph>
         </div>
         {children}
       </UtrechtAlert>

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -1627,8 +1627,12 @@
           }
         },
         "message": {
-          "row-gap": {
-            "value": "{rhc.space.0}",
+          "line-height": {
+            "value": "{rhc.line-height.md}",
+            "type": "lineHeights"
+          },
+          "column-gap": {
+            "value": "{rhc.space.100}",
             "type": "spacing"
           }
         },


### PR DESCRIPTION
closes #959

Added tokens:
- utrecht.alert.message.line-height = {rhc.line-height.md}
- utrecht.alert.message.column-gap = {rhc.space.100}

Removed token:
- utrecht.alert.message.row-gap (unneccessary token, value is default)