### PR TITLE
FEAT: Alert now also available as WC

### DIFF
--- a/packages/storybook/src/web-components/alert.stories.tsx
+++ b/packages/storybook/src/web-components/alert.stories.tsx
@@ -1,0 +1,108 @@
+/* @license CC0-1.0 */
+
+import { AlertWebComponent } from '@rijkshuisstijl-community/web-components';
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { mergeMarkdown } from '../../helpers/merge-markdown';
+import readme from '../community/alert.md?raw';
+
+AlertWebComponent.define();
+
+const meta = {
+  title: 'Web Components/Alert',
+  id: 'rhc-alert-web',
+  component: 'rhc-alert',
+  argTypes: {
+    type: {
+      description: 'Alert type',
+      control: { type: 'select' },
+      options: ['info', 'error', 'warning', 'ok'],
+      table: {
+        category: 'Property',
+      },
+    },
+    heading: {
+      description: 'Alert heading - used in default webcomponent slot',
+      type: {
+        name: 'string',
+      },
+      table: {
+        category: 'Demo',
+      },
+    },
+    headingLevel: {
+      description: 'Alert heading level',
+      control: { type: 'select' },
+      options: [1, 2, 3, 4, 5],
+      table: {
+        category: 'Demo',
+      },
+    },
+    messageText: {
+      description: 'Alert content - used in default webcomponent slot',
+      type: {
+        name: 'string',
+      },
+      table: {
+        category: 'Demo',
+      },
+    },
+  },
+  args: {
+    type: 'info',
+    heading: 'Heading',
+    headingLevel: 3,
+    messageText: 'Lorem ipsum dolor sit amet, consectetur ad * isicing elit, sed do eiusmod *',
+  },
+  tags: ['autodocs'],
+  parameters: {
+    status: {
+      type: 'STABLE',
+    },
+    docs: {
+      description: {
+        // TODO: disconnect "Usage" from the current readme, import the readme from Utrecht afterwards and combine with our own Usage
+        component: mergeMarkdown([readme]),
+      },
+    },
+    figma:
+      'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=1195-4201&t=n1djYpmvDCKmAEUi-0',
+    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/472',
+    nldesignsystem: 'https://www.nldesignsystem.nl/alert/',
+    componentOrigin:
+      'Dit component is overgenomen van de Gemeente Utrecht, met HTML aanpassingen en styling van de Rijkshuisstijl Community.',
+  },
+} as Meta<typeof AlertWebComponent>;
+
+export default meta;
+
+export const Informative = {
+  args: {
+    type: 'info',
+    heading: 'Heading',
+    messageText: 'Lorem ipsum dolor sit amet, consectetur ad * isicing elit, sed do eiusmod *',
+  },
+} as StoryObj<typeof meta>;
+
+export const Negative = {
+  args: {
+    type: 'error',
+    heading: 'Heading',
+    messageText: 'Lorem ipsum dolor sit amet, consectetur ad * isicing elit, sed do eiusmod *',
+  },
+} as StoryObj<typeof meta>;
+
+export const Positive = {
+  args: {
+    type: 'ok',
+    heading: 'Heading',
+    messageText: 'Lorem ipsum dolor sit amet, consectetur ad * isicing elit, sed do eiusmod *',
+  },
+} as StoryObj<typeof meta>;
+
+export const Warning = {
+  args: {
+    type: 'warning',
+    heading: 'Heading',
+    messageText: 'Lorem ipsum dolor sit amet, consectetur ad * isicing elit, sed do eiusmod *',
+  },
+} as StoryObj<typeof meta>;

--- a/packages/web-components/src/components/Alert.tsx
+++ b/packages/web-components/src/components/Alert.tsx
@@ -1,0 +1,31 @@
+import stylesheet from '@rijkshuisstijl-community/components-css/dist/index.css?inline';
+import { Alert, AlertProps } from '@rijkshuisstijl-community/components-react';
+import { BaseWebComponent } from './BaseComponent';
+
+export type AlertWebComponentAttributes = AlertProps;
+
+export class AlertWebComponent extends BaseWebComponent {
+  static override tagName: string = 'rhc-alert';
+  static override observedAttributes: string[] = ['type', 'heading', 'headinglevel', 'messagetext'];
+
+  constructor() {
+    super(stylesheet);
+  }
+
+  render(): void {
+    this.root.render(
+      <Alert
+        heading={(this.getAttribute('heading') as AlertProps['heading']) ?? 'default heading'}
+        type={(this.getAttribute('type') as AlertProps['type']) ?? 'info'}
+        headingLevel={
+          (this.getAttribute('headingLevel') && Number(this.getAttribute('headingLevel'))) as AlertProps['headingLevel']
+        }
+        textContent={
+          (this.getAttribute('messageText') as AlertProps['textContent']) ?? 'This is a default alert message.'
+        }
+      >
+        <slot />
+      </Alert>,
+    );
+  }
+}

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -1,3 +1,4 @@
 export { AccordionWebComponent, type AccordionWebComponentAttributes } from './components/Accordion';
 export { ActionGroupWebComponent, type ActionGroupWebComponentAttributes } from './components/ActionGroup';
+export { AlertWebComponent, type AlertWebComponentAttributes } from './components/Alert';
 export { HeroWebComponent, type HeroWebComponentAttributes } from './components/Hero';


### PR DESCRIPTION
#1112 

Hierbij is `textContent` een prop op ons React component, maar om dan `textContent` ook te gebruiken op ons web component geeft dit conflicten met textContent van native HTML ([bron](https://www.w3schools.com/jsref/prop_node_textcontent.asp)). Daarom is er gekozen om het `messageText` te noemen.