### PR TITLE
docs: readme states incorrectly that font can be imported before it installs in next step

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ pakket, en omring het deel van je applicatie waar je het thema wilt toepassen me
 
 ```tsx
 import '@rijkshuisstijl-community/design-tokens/dist/index.css'; // design tokens importeren
-import '@rijkshuisstijl-community/font/src/index.mjs'; // font importeren, mits je deze font wilt gebruiken.
 import '@rijkshuisstijl-community/components-css/dist/index.css'; // css importeren
 
 function App() {


### PR DESCRIPTION
Installation and import of font occurs in Licentie -> Fonts. User followed instructions of README and encountered "failed to resolve" error due to font being imported before install.