### PR TITLE
fix: link in card-footer should be wrapped in div

### DIFF
--- a/.changeset/eager-nails-flash.md
+++ b/.changeset/eager-nails-flash.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/components-react': patch
+---
+
+Link in card-footer should be wrapped in div instead of being preceded by empty div

--- a/packages/components-react/src/Card.tsx
+++ b/packages/components-react/src/Card.tsx
@@ -74,11 +74,12 @@ const DefaultCard = ({
       </div>
       {(linkLabel || button) && (
         <div className="rhc-card__footer">
-          <div className="rhc-card__link rhc-card__anchor"></div>
           {linkLabel && (
-            <Link aria-label={title} href={href} title={title}>
-              {linkLabel}
-            </Link>
+            <div className="rhc-card__link rhc-card__anchor">
+              <Link aria-label={title} href={href} title={title}>
+                {linkLabel}
+              </Link>
+            </div>
           )}
           {button && <div className="rhc-card__button">{button}</div>}
         </div>


### PR DESCRIPTION
Previously accidentally an empty div above the check, instead of wrapping the Link in the check. See https://github.com/nl-design-system/rijkshuisstijl-community/pull/1303#pullrequestreview-2632662390