### PR TITLE
feat(readme): split and append implementation to packages readmes (#1308)

### DIFF
--- a/.changeset/package-readme-css.md
+++ b/.changeset/package-readme-css.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/components-css': patch
+---
+
+Added implementation documentation to package README.

--- a/.changeset/package-readme-font.md
+++ b/.changeset/package-readme-font.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/font': patch
+---
+
+Moved implementation documentation from repository README to package README.

--- a/.changeset/package-readme-react.md
+++ b/.changeset/package-readme-react.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/components-react': patch
+---
+
+Moved implementation documentation from repository README to package README.

--- a/.changeset/package-readme-twig.md
+++ b/.changeset/package-readme-twig.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/components-twig': patch
+---
+
+Added implementation documentation to package README.

--- a/.changeset/package-readme-wc.md
+++ b/.changeset/package-readme-wc.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/web-components': patch
+---
+
+Added implementation documentation to package README.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 # Rijkshuisstijl Community Componenten
 
+**Direct aan de slag met [CSS](packages/components-css/README.md) | [React](packages/components-react/README.md) | [Web Components](packages/web-components/README.md) | [Twig](packages/components-twig/README.md)**
+
+---
+
 _Dit project wordt **niet** gesteund door het Ministerie van Algemene Zaken._
 
 **Het toepassen van design-elementen uit dit project is strikt verboden voor organisaties die geen deel uitmaken van de
@@ -35,56 +39,17 @@ juiste versie al is geïnstalleerd, of nadat hij is geïnstalleerd, wordt hij in
 
 De componenten gebruiken scss, zorg dat jouw project scss-bestanden kan verwerken.
 
-## Aan de slag zonder framework
+## Aan de slag
 
-Binnenkort komen er componenten die te gebruiken zijn zonder een framework.
+De componenten van de Rijkshuisstijl Community zijn te gebruiken met en zonder framework. Bekijk de README van elke package voor informatie over implementatie.
 
-## Aan de slag met React-componenten
-
-Om de React-componenten van de Rijkshuisstijl-community te gebruiken, installeer je het pakket dat beschikbaar in
-de [npm Registry](https://www.npmjs.com/package/@rijkshuisstijl-community/components-react).
-
-```npm
-npm install --save-dev @rijkshuisstijl-community/components-react
-```
-
-Dit installeert de React-componenten. Om deze componenten te gebruiken, kun je ze importeren in jouw app.
-
-```tsx
-'use client'; // Nodig in sommige projecten
-
-import { Button } from '@rijkshuisstijl-community/components-react';
-
-<Button>Click Here!</Button>;
-```
-
-Sommige componenten gebruiken de [useRef](https://react.dev/reference/react/useRef) hook, die alleen werkt in Client
-Componenten. Voeg `"use client"` toe bovenaan het bestand om dit op te lossen.
-
-### Thema toepassen
-
-De React-componenten hebben geen eigen styling. Om de Rijkshuisstijl aan je project toe te voegen, installeer je
-het [design-tokens npm package](https://www.npmjs.com/package/@rijkshuisstijl-community/design-tokens)
-
-```npm
-npm install --save-dev @rijkshuisstijl-community/design-tokens
-```
-
-Dit pakket bevat de CSS-variabelen van het design systeem. Importeer het `index.css`-bestand uit de `dist` map van het
-pakket, en omring het deel van je applicatie waar je het thema wilt toepassen met de Rijkshuisstijl-thema: `rhc-theme`.
-
-```tsx
-import '@rijkshuisstijl-community/design-tokens/dist/index.css'; // design tokens importeren
-import '@rijkshuisstijl-community/components-css/dist/index.css'; // css importeren
-
-function App() {
-  return (
-    <div className="rhc-theme">
-      <Button>Click Here!</Button>
-    </div>
-  );
-}
-```
+| Package                                                   | Purpose                                                                                                                                                                            |
+| :-------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`components-css`](packages/components-css/README.md)     | Hier kunnen CSS-componenten toegevoegd worden die nog niet bestaan in de NL Design System-community.                                                                               |
+| [`components-react`](packages/components-react/README.md) | Optioneel voor het toevoegen van een React-wrapper aan een CSS-component als die nog niet bestaat.                                                                                 |
+| [`web-components`](packages/web-components/README.md)     | Optioneel voor het toevoegen van een Web Component wrapper aan een CSS-component als die nog niet bestaat.                                                                         |
+| [`components-twig`](packages/components-twig/README.md)   | Optioneel voor het toevoegen van een Twig-wrapper aan een CSS-component als die nog niet bestaat.                                                                                  |
+| [`font`](packages/font/README.md)                         | Dit npm pakketje met fonts kun je gebruiken als alternatief op de officiële Rijkshuisstijl fonts, voor situaties waar je geen toestemming hebt om de officiële fonts te gebruiken. |
 
 ## Licentie
 
@@ -111,13 +76,7 @@ iconen.
 
 **_Lettertypen_**
 
-```npm
-npm install -D @rijkshuisstijl-community/font
-```
-
-```tsx
-import '@rijkshuisstijl-community/font/src/index.mjs';
-```
+Bekijk de [packages/font/README.md](packages/font/README.md) voor de meerdere manieren om de lettertypen te installeren voor jouw project.
 
 **_Logo_**
 
@@ -169,16 +128,6 @@ Vanuit`packages/components-react` krijg je een gedetailleerder overzicht van tes
 | Command         | Action                      |
 | :-------------- | :-------------------------- |
 | `pnpm run test` | Voert alle test suites uit. |
-
-### Packages
-
-| Package            | Purpose                                                                                                                                            |
-| :----------------- | :------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `components-css`   | Hier kunnen CSS-componenten toegevoegd worden die nog niet bestaan in de NL Design System-community.                                               |
-| `components-react` | Optioneel voor het toevoegen van een React-wrapper aan een CSS-component als die nog niet bestaat.                                                 |
-| `components-twig`  | Optioneel voor het toevoegen van een Twig-wrapper aan een CSS-component als die nog niet bestaat.                                                  |
-| `design-tokens`    | Hier worden de rijkshuisstijl-thema’s beheerd, voor gebruik met NL Design System zonder thema. Opmerking deze zouden naar proprietary moeten gaan. |
-| `storybook`        | Extra componenten en pagina-sjablonen kunnen worden toegevoegd als story voor documentatie en visuele regressietesten.                             |
 
 ### Proprietary
 

--- a/packages/components-css/README.md
+++ b/packages/components-css/README.md
@@ -1,0 +1,38 @@
+<!-- @license CC0-1.0 -->
+
+# Rijkshuisstijl Community Componenten - CSS
+
+_Dit project wordt **niet** gesteund door het Ministerie van Algemene Zaken._
+
+**Het toepassen van design-elementen uit dit project is strikt verboden voor organisaties die geen deel uitmaken van de
+centrale overheid van Nederland.**
+
+Deze package is onderdeel van het [Rijkshuisstijl Community](../../README.md) project.
+
+## Aan de slag met CSS-componenten
+
+Om de CSS-componenten van de Rijkshuisstijl-community te gebruiken, installeer je het [components-css npm package](https://www.npmjs.com/package/@rijkshuisstijl-community/components-css).
+
+```bash
+npm install --save-dev @rijkshuisstijl-community/components-css
+```
+
+Dit installeert de CSS-componenten. Om deze componenten te gebruiken, moet je het thema toepassen in de volgende stap.
+
+### Thema toepassen
+
+Om de Rijkshuisstijl aan je project toe te voegen, installeer je het [design-tokens npm package](https://www.npmjs.com/package/@rijkshuisstijl-community/design-tokens).
+
+```bash
+npm install --save-dev @rijkshuisstijl-community/design-tokens
+```
+
+Dit pakket bevat de CSS-variabelen van het design systeem. Importeer het `index.css`-bestand uit de `dist` map van het
+pakket, en omring het deel van je applicatie waar je het thema wilt toepassen met de Rijkshuisstijl-thema: `rhc-theme`.
+
+```scss
+@import '@rijkshuisstijl-community/design-tokens/dist/index.css'; // design tokens importeren
+@import '@rijkshuisstijl-community/components-css/dist/index.css'; // css importeren
+```
+
+Bekijk de [packages/font/README.md](packages/font/README.md) voor de meerdere manieren om de lettertypen te installeren voor jouw project.

--- a/packages/components-react/README.md
+++ b/packages/components-react/README.md
@@ -1,0 +1,57 @@
+<!-- @license CC0-1.0 -->
+
+# Rijkshuisstijl Community Componenten - React
+
+_Dit project wordt **niet** gesteund door het Ministerie van Algemene Zaken._
+
+**Het toepassen van design-elementen uit dit project is strikt verboden voor organisaties die geen deel uitmaken van de
+centrale overheid van Nederland.**
+
+Deze package is onderdeel van het [Rijkshuisstijl Community](../../README.md) project.
+
+## Aan de slag met React-componenten
+
+Om de React-componenten van de Rijkshuisstijl-community te gebruiken, installeer je het [components-react npm package](https://www.npmjs.com/package/@rijkshuisstijl-community/components-react).
+
+```bash
+npm install --save-dev @rijkshuisstijl-community/components-react
+```
+
+Dit installeert de React-componenten. Om deze componenten te gebruiken, kun je ze importeren in jouw app.
+
+```tsx
+'use client'; // Nodig in sommige projecten
+
+import { Button } from '@rijkshuisstijl-community/components-react';
+
+<Button>Click Here!</Button>;
+```
+
+Sommige componenten gebruiken de [useRef](https://react.dev/reference/react/useRef) hook, die alleen werkt in Client
+Componenten. Voeg `"use client"` toe bovenaan het bestand om dit op te lossen.
+
+### Thema toepassen
+
+De React-componenten hebben geen eigen styling. Om de Rijkshuisstijl aan je project toe te voegen, installeer je het [design-tokens npm package](https://www.npmjs.com/package/@rijkshuisstijl-community/design-tokens).
+
+```bash
+npm install --save-dev @rijkshuisstijl-community/design-tokens
+```
+
+Dit pakket bevat de CSS-variabelen van het design systeem. Importeer het `index.css`-bestand uit de `dist` map van het
+pakket, en omring het deel van je applicatie waar je het thema wilt toepassen met de Rijkshuisstijl-thema: `rhc-theme`.
+
+```tsx
+import '@rijkshuisstijl-community/design-tokens/dist/index.css'; // design tokens importeren
+import '@rijkshuisstijl-community/components-css/dist/index.css'; // css importeren
+
+function App() {
+  return (
+    <div className="rhc-theme">
+      <Button>Click Here!</Button>
+    </div>
+  );
+}
+```
+
+Bekijk de [packages/font/README.md](packages/font/README.md) voor de meerdere manieren om de lettertypen te installeren voor jouw project.

--- a/packages/components-twig/README.md
+++ b/packages/components-twig/README.md
@@ -1,0 +1,42 @@
+<!-- @license CC0-1.0 -->
+
+# Rijkshuisstijl Community Componenten - Twig
+
+_Dit project wordt **niet** gesteund door het Ministerie van Algemene Zaken._
+
+**Het toepassen van design-elementen uit dit project is strikt verboden voor organisaties die geen deel uitmaken van de
+centrale overheid van Nederland.**
+
+Deze package is onderdeel van het [Rijkshuisstijl Community](../../README.md) project.
+
+## Aan de slag met Twig-componenten
+
+Om de Twig-componenten van de Rijkshuisstijl-community te gebruiken, installeer je het [components-twig npm package](https://www.npmjs.com/package/@rijkshuisstijl-community/components-twig).
+
+```bash
+npm install --save-dev @rijkshuisstijl-community/components-twig
+```
+
+Om deze componenten te gebruiken, kun je ze importeren in jouw omgeving met behulp van de `@rhc` namespace.
+
+```twig
+{% "@rhc/OrderedListItem.twig %}
+```
+
+### Thema toepassen
+
+Om de Rijkshuisstijl aan je project toe te voegen, installeer je het [design-tokens npm package](https://www.npmjs.com/package/@rijkshuisstijl-community/design-tokens).
+
+```bash
+npm install --save-dev @rijkshuisstijl-community/design-tokens
+```
+
+Dit pakket bevat de CSS-variabelen van het design systeem. Importeer het `index.css`-bestand uit de `dist` map van het
+pakket, en omring het deel van je applicatie waar je het thema wilt toepassen met de Rijkshuisstijl-thema: `rhc-theme`.
+
+```scss
+@import '@rijkshuisstijl-community/design-tokens/dist/index.css'; // design tokens importeren
+@import '@rijkshuisstijl-community/components-css/dist/index.css'; // css importeren
+```
+
+Bekijk de [packages/font/README.md](packages/font/README.md) voor de meerdere manieren om de lettertypen te installeren voor jouw project.

--- a/packages/font/README.md
+++ b/packages/font/README.md
@@ -31,6 +31,12 @@ Gebruik in JavaScript frameworks zoals React en Angular de volgende code:
 import '@rijkshuisstijl-community/font/src/index.mjs';
 ```
 
+Gebruik in SCSS de volgende code:
+
+```scss
+@import '@rijkshuisstijl-community/font/src/index.scss';
+```
+
 ## Op zoek naar de officiële lettertypes?
 
 De officiële lettertypes kun je downloaden via [rijkshuisstijl.nl](https://www.rijkshuisstijl.nl/publiek/modules/product/DigitalStyleGuide/default/index.aspx?ItemId=6745), als je voldoende rechten hebt. Bijvoorbeeld als je bij de Rijksoverheid werkt en je ingelogd bent via Citrix.

--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -1,0 +1,54 @@
+<!-- @license CC0-1.0 -->
+
+# Rijkshuisstijl Community Componenten - Web Components
+
+_Dit project wordt **niet** gesteund door het Ministerie van Algemene Zaken._
+
+**Het toepassen van design-elementen uit dit project is strikt verboden voor organisaties die geen deel uitmaken van de
+centrale overheid van Nederland.**
+
+Deze package is onderdeel van het [Rijkshuisstijl Community](../../README.md) project.
+
+## Aan de slag met Web Components
+
+Om de Web Components van de Rijkshuisstijl-community te gebruiken, installeer je het [web-components npm package](https://www.npmjs.com/package/@rijkshuisstijl-community/web-components).
+
+```bash
+npm install --save-dev @rijkshuisstijl-community/web-components
+```
+
+Dit installeert de Web Components. Om deze componenten te gebruiken, importeer je ze in je project en plaats je ze in de HTML.
+
+Importeer de Web Components in je project:
+
+```js
+import '@rijkshuisstijl-community/web-components';
+```
+
+Vervolgens kun je de componenten in je HTML gebruiken:
+
+```html
+<rhc-button>Click Here!</rhc-button>
+```
+
+### Thema toepassen
+
+De Web Components hebben geen eigen styling. Om de Rijkshuisstijl aan je project toe te voegen, installeer je het [design-tokens npm package](https://www.npmjs.com/package/@rijkshuisstijl-community/design-tokens).
+
+```bash
+npm install --save-dev @rijkshuisstijl-community/design-tokens
+```
+
+Dit pakket bevat de CSS-variabelen van het design systeem. Importeer het `index.css`-bestand uit de `dist` map van het
+pakket, en omring het deel van je applicatie waar je het thema wilt toepassen met de Rijkshuisstijl-thema: `rhc-theme`.
+
+```html
+<link rel="stylesheet" href="node_modules/@rijkshuisstijl-community/design-tokens/dist/index.css" />
+<link rel="stylesheet" href="node_modules/@rijkshuisstijl-community/components-css/dist/index.css" />
+
+<div class="rhc-theme">
+  <rhc-button>Click Here!</rhc-button>
+</div>
+```
+
+Bekijk de [packages/font/README.md](packages/font/README.md) voor de meerdere manieren om de lettertypen te installeren voor jouw project.


### PR DESCRIPTION
Zoals beschreven in #1308 willen we components-twig documenteren. In plaats van een lange README te maken met alle framework(less) implementaties, hebben we de implementatie informatie verplaatst naar de README van de package. Dit zorgt er ook voor dat de package op npm netjes informatie bevat. Zie ticket voor alle informatie.

Graag ontvang ik feedback van het team op:
- Wat vind je van deze opzet? Voegt het waarde toe, of juist niet? Zou je het anders doen?
- Is de informatie correct? Voor React heb ik het enkel aangevuld. Voor Twig, CSS en Web Components heb ik het geschreven.

Closes #1308 