### PR TITLE
Fix/card as link

### DIFF
--- a/.changeset/kind-otters-say.md
+++ b/.changeset/kind-otters-say.md
@@ -1,0 +1,6 @@
+---
+'@rijkshuisstijl-community/components-react': minor
+'@rijkshuisstijl-community/components-css': minor
+---
+
+Adjusted DOM order of `card` component to improve screen reader accessibility per WCAG guidelines, placing headings before images. Visual layout preserved using flex order.

--- a/packages/components-css/src/card/_mixin.scss
+++ b/packages/components-css/src/card/_mixin.scss
@@ -132,7 +132,6 @@
   display: flex;
   font-size: var(--rhc-card-as-link-heading-font-size, 24px);
   font-weight: var(--rhc-card-as-link-heading-font-weight, 700);
-  order: 2;
 }
 
 @mixin rhc-card__heading--active {

--- a/packages/components-css/src/card/_mixin.scss
+++ b/packages/components-css/src/card/_mixin.scss
@@ -87,6 +87,7 @@
   color: var(--rhc-card-as-link-horizontal-color, white);
   column-gap: var(--rhc-card-as-link-column-gap, 16px);
   flex-direction: row;
+  order: 2;
   padding-block-end: var(--rhc-card-as-link-horizontal-padding-block-end, 0);
   padding-block-start: var(--rhc-card-as-link-horizontal-padding-block-start, 0);
   padding-inline-end: var(--rhc-card-as-link-horizontal-padding-inline-end, 0);
@@ -122,12 +123,21 @@
   max-block-size: var(--rhc-card-as-link-horizontal-max-block-size);
 }
 
+.rhc-card__image-container {
+  order: 1;
+}
+
 @mixin rhc-card__heading {
   align-items: center;
   color: var(--rhc-card-as-link-heading-color, #154273);
   display: flex;
   font-size: var(--rhc-card-as-link-heading-font-size, 24px);
   font-weight: var(--rhc-card-as-link-heading-font-weight, 700);
+  order: 2;
+}
+
+.rhc-card__description {
+  order: 3;
 }
 
 @mixin rhc-card__heading--active {
@@ -144,11 +154,13 @@
 
 @mixin rhc-card__icon {
   color: var(--rhc-card-as-link-icon-color, #154273);
+  order: 4;
   size: var(--rhc-card-as-link-icon-size, 24px);
 }
 
 @mixin rhc-card__link {
   color: var(--rhc-card-as-link-link-color, #01689b);
+  order: 6;
   text-decoration: var(--rhc-card-as-link-link-text-decoration, underline);
 }
 
@@ -177,6 +189,7 @@
 
 @mixin rhc-card__metadata {
   color: var(--rhc-card-as-link-metadata-color, #154273);
+  order: 5;
 }
 
 @mixin rounded-border-corners {

--- a/packages/components-css/src/card/_mixin.scss
+++ b/packages/components-css/src/card/_mixin.scss
@@ -63,6 +63,10 @@
   z-index: 1;
 }
 
+@mixin rhc-card__image-container {
+  order: -1;
+}
+
 @mixin rhc-card__image {
   aspect-ratio: 16 / 9;
   block-size: 100%;
@@ -87,7 +91,6 @@
   color: var(--rhc-card-as-link-horizontal-color, white);
   column-gap: var(--rhc-card-as-link-column-gap, 16px);
   flex-direction: row;
-  order: 2;
   padding-block-end: var(--rhc-card-as-link-horizontal-padding-block-end, 0);
   padding-block-start: var(--rhc-card-as-link-horizontal-padding-block-start, 0);
   padding-inline-end: var(--rhc-card-as-link-horizontal-padding-inline-end, 0);
@@ -123,10 +126,6 @@
   max-block-size: var(--rhc-card-as-link-horizontal-max-block-size);
 }
 
-.rhc-card__image-container {
-  order: 1;
-}
-
 @mixin rhc-card__heading {
   align-items: center;
   color: var(--rhc-card-as-link-heading-color, #154273);
@@ -134,10 +133,6 @@
   font-size: var(--rhc-card-as-link-heading-font-size, 24px);
   font-weight: var(--rhc-card-as-link-heading-font-weight, 700);
   order: 2;
-}
-
-.rhc-card__description {
-  order: 3;
 }
 
 @mixin rhc-card__heading--active {
@@ -154,13 +149,11 @@
 
 @mixin rhc-card__icon {
   color: var(--rhc-card-as-link-icon-color, #154273);
-  order: 4;
   size: var(--rhc-card-as-link-icon-size, 24px);
 }
 
 @mixin rhc-card__link {
   color: var(--rhc-card-as-link-link-color, #01689b);
-  order: 6;
   text-decoration: var(--rhc-card-as-link-link-text-decoration, underline);
 }
 
@@ -189,7 +182,6 @@
 
 @mixin rhc-card__metadata {
   color: var(--rhc-card-as-link-metadata-color, #154273);
-  order: 5;
 }
 
 @mixin rounded-border-corners {

--- a/packages/components-css/src/card/index.scss
+++ b/packages/components-css/src/card/index.scss
@@ -31,6 +31,11 @@
 .rhc-card__footer {
   @include mixin.rhc-card__content;
 }
+
+.rhc-card__image-container {
+  @include mixin.rhc-card__image-container;
+}
+
 .rhc-card__image {
   @include mixin.rhc-card__image;
 }

--- a/packages/components-react/src/Card.test.tsx
+++ b/packages/components-react/src/Card.test.tsx
@@ -79,38 +79,58 @@ describe('Card', () => {
     });
   });
 
-  describe('FullBleedCard', () => {
-    it('renders a visible element', () => {
-      const { container } = render(<FullBleedCard heading="Heading" href="#" imageAlt="Test" imageSrc="#" />);
-      const navBar = container.querySelector(':only-child');
-      expect(navBar).toBeInTheDocument();
-      expect(navBar).toBeVisible();
-    });
+  describe('accessibility', () => {
+    it('renders heading before image in the DOM to ensure correct reading order', () => {
+      // In de HTML-structuur (DOM) staat de heading voor de afbeelding.
+      // Dit zorgt ervoor dat screenreaders de content in de juiste volgorde kunnen voorlezen.
+      // De visuele volgorde kan los daarvan met CSS worden aangepast, zonder impact op toegankelijkheid.
 
-    it('renders a link with the correct href and title', () => {
-      linkTest(
-        <FullBleedCard heading="Heading" href="/example" imageAlt="Test" imageSrc="#" title="Example Title" />,
-        '/example',
-        'Example Title',
-      );
+      const { getByText, getByAltText } = render(<Card heading="Heading" imageAlt="An example image" imageSrc="#" />);
+
+      const headingElement = getByText('Heading');
+      const imageElement = getByAltText('An example image');
+
+      // Controleer of beide elementen zichtbaar zijn
+      expect(headingElement).toBeVisible();
+      expect(imageElement).toBeVisible();
+
+      // Controleer of de heading vóór de afbeelding staat in de DOM-structuur
+      expect(headingElement.compareDocumentPosition(imageElement)).toBe(Node.DOCUMENT_POSITION_PRECEDING);
     });
   });
+});
 
-  describe('HorizontalImageCard', () => {
-    it('renders a visible element', () => {
-      const { container } = render(<HorizontalImageCard heading="Heading" href="#" imageAlt="Test" imageSrc="#" />);
-      const navBar = container.querySelector(':only-child');
-      expect(navBar).toBeInTheDocument();
-      expect(navBar).toBeVisible();
-    });
+describe('FullBleedCard', () => {
+  it('renders a visible element', () => {
+    const { container } = render(<FullBleedCard heading="Heading" href="#" imageAlt="Test" imageSrc="#" />);
+    const navBar = container.querySelector(':only-child');
+    expect(navBar).toBeInTheDocument();
+    expect(navBar).toBeVisible();
+  });
 
-    it('renders a link with the correct href and title', () => {
-      linkTest(
-        <HorizontalImageCard heading="Heading" href="/example" imageAlt="Test" imageSrc="#" title="Example Title" />,
-        '/example',
-        'Example Title',
-      );
-    });
+  it('renders a link with the correct href and title', () => {
+    linkTest(
+      <FullBleedCard heading="Heading" href="/example" imageAlt="Test" imageSrc="#" title="Example Title" />,
+      '/example',
+      'Example Title',
+    );
+  });
+});
+
+describe('HorizontalImageCard', () => {
+  it('renders a visible element', () => {
+    const { container } = render(<HorizontalImageCard heading="Heading" href="#" imageAlt="Test" imageSrc="#" />);
+    const navBar = container.querySelector(':only-child');
+    expect(navBar).toBeInTheDocument();
+    expect(navBar).toBeVisible();
+  });
+
+  it('renders a link with the correct href and title', () => {
+    linkTest(
+      <HorizontalImageCard heading="Heading" href="/example" imageAlt="Test" imageSrc="#" title="Example Title" />,
+      '/example',
+      'Example Title',
+    );
   });
 });
 

--- a/packages/components-react/src/Card.test.tsx
+++ b/packages/components-react/src/Card.test.tsx
@@ -95,7 +95,7 @@ describe('Card', () => {
       expect(imageElement).toBeVisible();
 
       // Controleer of de heading vóór de afbeelding staat in de DOM-structuur
-      expect(headingElement.compareDocumentPosition(imageElement)).toBe(Node.DOCUMENT_POSITION_PRECEDING);
+      expect(headingElement.compareDocumentPosition(imageElement)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     });
   });
 });

--- a/packages/components-react/src/Card.tsx
+++ b/packages/components-react/src/Card.tsx
@@ -67,13 +67,13 @@ const DefaultCard = ({
   return (
     <div className={clsx('rhc-card', 'rhc-card--default', className)} ref={ref} {...restProps}>
       <div className="rhc-card__content">
-        {imageSrc && imageAlt && (
+        <div className="rhc-card__heading">{heading}</div>
+        {imageSrc && (
           <div className="rhc-card__image-container" data-testid="rhc-card__image-container">
             {<Image alt={imageAlt} className="rhc-card__image" src={imageSrc} />}
           </div>
         )}
         <div className="rhc-card__icon">{icon}</div>
-        <div className="rhc-card__heading">{heading}</div>
         <div className="rhc-card__description">{description}</div>
         <div className="rhc-card__metadata">{metadata}</div>
         {children}
@@ -117,13 +117,13 @@ export const FullBleedCard = ({
     <span className="rhc-card__anchor">
       <a aria-label={title} href={href} title={title}></a>
     </span>
-    {<Image alt={imageAlt} className="rhc-card__image" src={imageSrc} />}
     <div className="rhc-card__content">
       <div className="rhc-card__heading">{heading}</div>
       <div className="rhc-card__description">{description}</div>
       <div className="rhc-card__metadata">{metadata}</div>
       {children}
     </div>
+    {<Image alt={imageAlt} className="rhc-card__image" src={imageSrc} />}
   </div>
 );
 
@@ -144,12 +144,12 @@ export const HorizontalImageCard = ({
     <span className="rhc-card__anchor">
       <a aria-label={title} href={href} title={title}></a>
     </span>
-    <div className="rhc-card__image-container">
-      <Image alt={imageAlt} className="rhc-card__image" src={imageSrc} />
-    </div>
     <div className="rhc-card__content">
       <div className="rhc-card__heading">{heading}</div>
       {children}
+    </div>
+    <div className="rhc-card__image-container">
+      <Image alt={imageAlt} className="rhc-card__image" src={imageSrc} />
     </div>
   </div>
 );

--- a/packages/components-react/src/Card.tsx
+++ b/packages/components-react/src/Card.tsx
@@ -67,6 +67,8 @@ const DefaultCard = ({
   return (
     <div className={clsx('rhc-card', 'rhc-card--default', className)} ref={ref} {...restProps}>
       <div className="rhc-card__content">
+        {/* De heading moet vóór de afbeelding komen in de DOM, 
+          zodat screen readers de informatie op de juiste manier kunnen presenteren aan gebruikers. */}
         <div className="rhc-card__heading">{heading}</div>
         {imageSrc && (
           <div className="rhc-card__image-container" data-testid="rhc-card__image-container">
@@ -118,6 +120,8 @@ export const FullBleedCard = ({
       <a aria-label={title} href={href} title={title}></a>
     </span>
     <div className="rhc-card__content">
+      {/* De heading moet vóór de afbeelding komen in de DOM, 
+          zodat screen readers de informatie op de juiste manier kunnen presenteren aan gebruikers. */}
       <div className="rhc-card__heading">{heading}</div>
       <div className="rhc-card__description">{description}</div>
       <div className="rhc-card__metadata">{metadata}</div>
@@ -145,6 +149,8 @@ export const HorizontalImageCard = ({
       <a aria-label={title} href={href} title={title}></a>
     </span>
     <div className="rhc-card__content">
+      {/* De heading moet vóór de afbeelding komen in de DOM, 
+          zodat screen readers de informatie op de juiste manier kunnen presenteren aan gebruikers. */}
       <div className="rhc-card__heading">{heading}</div>
       {children}
     </div>

--- a/packages/components-react/src/Card.tsx
+++ b/packages/components-react/src/Card.tsx
@@ -67,8 +67,6 @@ const DefaultCard = ({
   return (
     <div className={clsx('rhc-card', 'rhc-card--default', className)} ref={ref} {...restProps}>
       <div className="rhc-card__content">
-        {/* De heading moet vóór de afbeelding komen in de DOM, 
-          zodat screen readers de informatie op de juiste manier kunnen presenteren aan gebruikers. */}
         <div className="rhc-card__heading">{heading}</div>
         {imageSrc && (
           <div className="rhc-card__image-container" data-testid="rhc-card__image-container">
@@ -120,8 +118,6 @@ export const FullBleedCard = ({
       <a aria-label={title} href={href} title={title}></a>
     </span>
     <div className="rhc-card__content">
-      {/* De heading moet vóór de afbeelding komen in de DOM, 
-          zodat screen readers de informatie op de juiste manier kunnen presenteren aan gebruikers. */}
       <div className="rhc-card__heading">{heading}</div>
       <div className="rhc-card__description">{description}</div>
       <div className="rhc-card__metadata">{metadata}</div>
@@ -149,8 +145,6 @@ export const HorizontalImageCard = ({
       <a aria-label={title} href={href} title={title}></a>
     </span>
     <div className="rhc-card__content">
-      {/* De heading moet vóór de afbeelding komen in de DOM, 
-          zodat screen readers de informatie op de juiste manier kunnen presenteren aan gebruikers. */}
       <div className="rhc-card__heading">{heading}</div>
       {children}
     </div>


### PR DESCRIPTION
### [Card as Link](https://rijkshuisstijl-community.vercel.app/?path=/docs/rhc-card--docs)

[Issue](https://github.com/orgs/frameless/projects/58/views/6?visibleFields=%5B%22Title%22%2C%22Assignees%22%2C%22Status%22%2C%22Labels%22%5D&layout=board&pane=issue&itemId=100677309&issue=frameless%7Cdeveloper.overheid.nl%7C62)

De huidige implementatie van de card-elementen voldoet niet aan de toegankelijkheidseisen voor gebruikers met een screenreader, volgens de WCAG-richtlijnen. Het is essentieel dat zij eerst de heading en vervolgens de image kunnen horen. 

Om dit op te lossen, heb ik de volgorde in de DOM aangepast door de heading boven de image te plaatsen. Hierdoor kunnen screenreaders de inhoud in de juiste volgorde voorlezen. Vervolgens heb ik met flex `order` de visuele volgorde van de elementen aangepast naar het oorspronkelijke design. 

Dit betekent dat de lay-out voor visuele gebruikers hetzelfde is gebleven, terwijl de toegankelijkheid voor screenreaders is verbeterd, zonder dat er iets aan de gebruikersinterface is veranderd.

Om te voorkomen dat dit probleem opnieuw optreedt, heb ik comments toegevoegd in de DOM om het voor anderen duidelijker te maken. Daarnaast heb ik een unit test geschreven, met extra toelichting in de vorm van comments voor extra helderheid.