### PR TITLE
chore: automatically cancel Vercel jobs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "github": {
+    "autoJobCancellation": true
+  }
+}


### PR DESCRIPTION
New pushes to the same branch will cancel running builds.