### PR TITLE
Feat/html language decorator

### DIFF
--- a/apps/rhc-templates/src/app/developer-overheid/homepage/page.tsx
+++ b/apps/rhc-templates/src/app/developer-overheid/homepage/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import PageContent from '@rijkshuisstijl-community/storybook/src/templates/developer-overheid/homepage';
+
+export default function Page() {
+  return <PageContent />;
+}

--- a/apps/rhc-templates/src/app/layout.tsx
+++ b/apps/rhc-templates/src/app/layout.tsx
@@ -11,7 +11,7 @@ import Head from 'next/head';
 
 export default function RootLayout({ children }: PropsWithChildren<{}>) {
   return (
-    <Root>
+    <Root lang="nl" dir="ltr">
       <Head>
         <title>Rijkshuisstijl demo - Index</title>
       </Head>

--- a/packages/storybook/config/StoryRootDecorator.tsx
+++ b/packages/storybook/config/StoryRootDecorator.tsx
@@ -1,0 +1,41 @@
+import type { Decorator } from '@storybook/react';
+import { type CSSProperties, useEffect } from 'react';
+
+export const StoryRootDecorator: Decorator = (Story, context) => {
+  const { storyRootClassname, dir, lang, title, writingMode, zoom } = context.globals;
+  const style: CSSProperties = zoom ? { zoom } : {};
+
+  // In Storybook there are different view modes. When looking at all stories,
+  // the url is something like: `iframe.html?viewMode=docs&...`
+  //
+  // When looking at one just one Story, the URL is like: `iframe.html?viewMode=docs&...`
+  // ? Bovenstaande URL's zijn gelijk?
+  //
+  // Here we will recongnize such an URL, and render the Story settings on page level,
+  // to conform to the following WCAG 2.2 Success criteria:
+  //
+  // - Page title: https://nldesignsystem.nl/wcag/2.4.2
+  // - Language of the page: https://nldesignsystem.nl/wcag/3.1.1
+  const { viewMode } = context;
+
+  useEffect(() => {
+    if (viewMode === 'story') {
+      document.title = title || context.name;
+      document.documentElement.lang = lang;
+      document.documentElement.dir = dir || '';
+      document.documentElement.style.writingMode = writingMode || '';
+    } else if (viewMode === 'docs') {
+      // Restore the title, dir and lang to sensible defaults
+      document.title = context.title;
+      document.documentElement.lang = 'nl';
+      document.documentElement.dir = 'ltr';
+      document.documentElement.style.writingMode = 'initial';
+    }
+  }, [context.name]);
+
+  return (
+    <div data-story-root className={storyRootClassname} dir={dir} lang={lang} style={style}>
+      <Story />
+    </div>
+  );
+};

--- a/packages/storybook/config/preview.tsx
+++ b/packages/storybook/config/preview.tsx
@@ -15,6 +15,7 @@ import { Controls, Description, Primary, Stories, useOf } from '@storybook/block
 import { Preview } from '@storybook/react';
 import { PageLayout } from '@utrecht/page-layout-react';
 import { Root } from '@utrecht/root-react';
+import { StoryRootDecorator } from 'config/StoryRootDecorator';
 import { Fragment } from 'react';
 
 const preview: Preview = {
@@ -41,6 +42,7 @@ const preview: Preview = {
         Story()
       );
     },
+    StoryRootDecorator,
   ],
   parameters: {
     previewTabs: {

--- a/packages/storybook/src/templates/developer-overheid/homepage/index.tsx
+++ b/packages/storybook/src/templates/developer-overheid/homepage/index.tsx
@@ -1,0 +1,211 @@
+import {
+  Card,
+  Figure,
+  Footer,
+  Icon,
+  Image,
+  LinkList,
+  LinkListLink,
+  Logo,
+  NavBar,
+  PageContent,
+  PageHeader,
+  SkipLink,
+  // TextInput,
+} from '@rijkshuisstijl-community/components-react';
+import { IconArrowUp, IconSearch } from '@tabler/icons-react';
+import { Button, Heading, Paragraph, ScrollLink } from '@utrecht/component-library-react';
+// import { BadgeList, DataBadge } from '@utrecht/component-library-react';
+import { PageBody } from '@utrecht/page-body-react';
+
+<html lang="nl" />;
+
+export default function DevOvhHomepage() {
+  return (
+    <>
+      <SkipLink className="rhc-skip-link--visible-on-focus" href="#main" id="top">
+        Ga naar hoofdinhoud
+      </SkipLink>
+      <PageHeader className="rhc-header-wrapper">
+        <title>Developer Overheid - Homepage</title>
+        <Figure>
+          <Logo organisation="" subtitle="">
+            <Icon icon="nederland-map" />
+          </Logo>
+
+          <div className="rhc-logo-container">
+            <div className="rhc-logo-heading">
+              <Image
+                alt="Developer Overheid logo"
+                height={35}
+                src="https://developer.overheid.nl/img/logo-don.svg"
+                width={35}
+              ></Image>
+              <Heading className="rhc-logo-main-heading" level={1}>
+                developers.overheid.nl
+              </Heading>
+            </div>
+            <Paragraph className="rhc-logo-paragraph">Ontwikkelaarsportaal van de Nederlandse overheid</Paragraph>
+          </div>
+        </Figure>
+      </PageHeader>
+
+      <NavBar
+        endItems={[
+          { id: '1', href: '/', label: 'Forum' },
+          { id: '2', href: '/', label: 'APIs' },
+          { id: '3', href: '/', label: 'Open Source' },
+          { id: '4', href: '/', label: 'Open Data' },
+          { id: '5', href: '/', label: 'Geodata' },
+        ]}
+        items={[
+          { id: '1', href: '/developer-overheid/homepage', label: 'Home' },
+          { id: '2', href: '/', label: 'Kennisbank' },
+          { id: '3', href: '/', label: 'Communities' },
+          { id: '4', href: '/', label: 'Blog' },
+        ]}
+      >
+        <Button appearance="">
+          <IconSearch></IconSearch>
+        </Button>
+        {/* <TextInput aria-label="text-input-label" name="subject" placeholder="Zoek"></TextInput> */}
+      </NavBar>
+
+      <PageBody className="rhc-templates-main-content rhc-templates-page-body">
+        <main id="main">
+          <PageContent className="rhc-templates-page-content">
+            {/* <Hero
+              aspectRatio="16 / 9"
+              heading="Informatie, bronnen en tools van de overheid voor ontwikkelaars door Kennisplatform API's, Digilab, Opensourcewerken, Binnenlandse Zaken, Geonovum, Belastingdienst, Kadaster en andere overheidsinstanties.."
+              headingLevel={1}
+              imageAlt="Sterrenhemel"
+              imageSrc=""
+            ></Hero> */}
+
+            {/* <Hero
+              imageAlt="Tullip field"
+              imageSrc="https://media.istockphoto.com/id/1369277204/vector/turquoise-green-starry-sky-illustration.jpg?s=612x612&w=0&k=20&c=zt_-oaVq_8yNHVe61pZQZ2nQXY6j0QiY6u09oScn8xU="
+            >
+              <LinkListCard
+                heading="Informatie, bronnen en tools van de overheid voor ontwikkelaars door Kennisplatform API's, Digilab, Opensourcewerken, Binnenlandse Zaken, Geonovum, Belastingdienst, Kadaster en andere overheidsinstanties."
+                headingLevel={2}
+              ></LinkListCard>
+              <Heading level={1}>
+                Informatie, bronnen en tools van de overheid voor ontwikkelaars door Kennisplatform APIs, Digilab,
+                Opensourcewerken, Binnenlandse Zaken, Geonovum, Belastingdienst, Kadaster en andere overheidsinstanties.
+              </Heading>
+            </Hero> */}
+
+            <section className="rhc-cards-container">
+              <Card
+                className="rhc-card-box"
+                description="Tutorials, tools, code voorbeelden en meer. Alles wat je nodig hebt om aan de slag te gaan met software van en voor de overheid."
+                heading="Kennisbank"
+                href="#"
+                imageAlt="Een open boek"
+                imageSrc="	https://developer.overheid.nl/img/boek-opengeslagen.svg"
+                linkLabel="Ga naar de kennisbank"
+                metadata=""
+                title="Kennisbank"
+              ></Card>
+              <Card
+                className="rhc-card-box"
+                description="Ga in gesprek met andere developers en vind hier getting started guides, tutorials en tools."
+                heading="Onze community"
+                href="#"
+                imageAlt="Twee praat wolkjes die symbool staan voor in gesprek gaan met elkaar"
+                imageSrc="https://don.apps.digilab.network/img/tekstballonnen-met-punten.svg"
+                linkLabel="Ga naar het forum"
+                metadata=""
+                title="Onze community"
+              ></Card>
+              <Card
+                className="rhc-card-box"
+                description="Bekijk welke API‘s er allemaal zijn en kom er achter hoe je jouw oplossing hier op kan laten aansluiten."
+                heading="Vind een API"
+                href="#"
+                imageAlt="Een wereld bol met daarbinnen connected dots, dit staat stymbool voor aansluiten"
+                imageSrc="https://don.apps.digilab.network/img/ict.svg"
+                linkLabel="Ga naar het API register"
+                metadata=""
+                title="Vind een API"
+              ></Card>
+              <Card
+                className="rhc-card-box"
+                description="Vind bestaande repositories om bij aan te haken en ontdek wat er binnen welke organisatie beschikbaar is."
+                heading="Vind een repository"
+                href="#"
+                imageAlt="Een beeldscherm met een HTML closing tag, symbool voor computer code"
+                imageSrc="https://don.apps.digilab.network/img/computercode.svg"
+                linkLabel="Ga naar het OSS register"
+                metadata=""
+                title="Vind een repository"
+              ></Card>
+            </section>
+          </PageContent>
+        </main>
+        <ScrollLink appearance="subtle-button" href="#top">
+          Terug naar boven <IconArrowUp />
+        </ScrollLink>
+      </PageBody>
+
+      <Footer
+        // backtotop
+        appearanceLevel={4}
+        background="primary-filled"
+        heading="Mede mogelijk gemaakt door:"
+        columns={[
+          {
+            appearanceLevel: 4,
+            heading: 'Community',
+            children: [
+              <LinkList key="1">
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
+                  Discourse
+                </LinkListLink>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
+                  Slack
+                </LinkListLink>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
+                  GitHub
+                </LinkListLink>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
+                  Mastodon
+                </LinkListLink>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
+                  LinkedIn
+                </LinkListLink>
+              </LinkList>,
+            ],
+          },
+          {
+            appearanceLevel: 4,
+            heading: 'Overig',
+            children: (
+              <LinkList key="2">
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
+                  Bijdragen
+                </LinkListLink>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
+                  Implementatie ondersteuning{' '}
+                </LinkListLink>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
+                  Contact
+                </LinkListLink>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
+                  Privacyverklaring
+                </LinkListLink>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
+                  Toegankelijkheids verklaring
+                </LinkListLink>
+                <LinkListLink href="#" icon={<Icon icon={'chevron-right'} />}>
+                  Sitearchief
+                </LinkListLink>
+              </LinkList>
+            ),
+          },
+        ]}
+      />
+    </>
+  );
+}

--- a/packages/storybook/src/templates/globals.css
+++ b/packages/storybook/src/templates/globals.css
@@ -18,6 +18,31 @@ h1 {
   background-color: #f2f4f6;
 }
 
+.rhc-templates-databadge {
+  /* --utrecht-data-badge-background-color: blue;
+  --utrecht-data-badge-color: red; */
+  background-color: #fff !important;
+  color: darkblue;
+  max-inline-size: 12em;
+  padding-block: 0.5em;
+  padding-inline: 0.5em;
+}
+
+.rhc-badgelist-databadge {
+  background-color: #fff !important;
+  border: solid 1px grey;
+  border-radius: 13px;
+  color: grey;
+  max-inline-size: 12em;
+  padding-block: 0.25rem;
+  padding-inline: 0.75rem;
+}
+
+.rhc-badgelist {
+  display: flex;
+  gap: 0.3rem !important;
+}
+
 .rhc-templates-unstarted {
   border: 2px dashed red;
 }
@@ -49,6 +74,11 @@ h1 {
   align-items: center;
   display: flex;
   justify-content: center;
+}
+
+.rhc-templates-page-body {
+  margin-inline: auto;
+  max-inline-size: 1280px;
 }
 
 .rhc-templates-page-content {
@@ -103,12 +133,18 @@ h1 {
 .rhc-templates-card-container {
   column-gap: var(--rhc-space-300);
   display: flex;
+  flex-wrap: wrap;
   margin-block-end: var(--rhc-space-400);
   margin-block-start: var(--rhc-space-300);
   row-gap: var(--rhc-space-300);
   @media (width <= 780px) {
     flex-direction: column;
   }
+}
+
+.rhc-card--full-bleed {
+  background-color: #f2f4f6;
+  color: #154273 !important;
 }
 
 .rhc-side-nav {
@@ -146,4 +182,65 @@ h1 {
 
 .rhc-nav-bar__list {
   flex-wrap: wrap;
+}
+
+.rhc-cards-container {
+  display: grid;
+  gap: 1em;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  justify-content: center;
+}
+
+@media (width < 1350px) {
+  .rhc-cards-container {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (width < 700px) {
+  .rhc-cards-container {
+    grid-template-columns: 1fr;
+  }
+}
+
+.rhc-dev-logo {
+  align-items: end;
+  display: grid;
+}
+
+.rhc-logo-container {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+}
+
+@media (width < 800px) {
+  .rhc-logo-container {
+    align-items: center;
+    text-align: center;
+  }
+}
+
+.rhc-header-wrapper {
+  margin-inline: auto;
+  max-inline-size: 1260px;
+}
+
+.rhc-logo-heading {
+  align-items: flex-end;
+  display: flex;
+  font-size: 1rem !important;
+  gap: 10px;
+}
+
+.rhc-logo-main-heading {
+  font-size: 1.5rem !important;
+}
+.rhc-logo-paragraph {
+  font-size: 1rem !important;
+}
+
+.rhc-card-box {
+  inline-size: 305px !important;
 }

--- a/packages/storybook/src/templates/homepage.stories.tsx
+++ b/packages/storybook/src/templates/homepage.stories.tsx
@@ -1,0 +1,27 @@
+import { Meta, StoryObj } from '@storybook/react';
+import './globals.css';
+import DevOvhHomepage from './developer-overheid/homepage';
+
+const meta = {
+  title: 'Templates/Developer Overheid Homepage',
+  component: DevOvhHomepage,
+  parameters: {
+    status: {
+      type: 'UNSTABLE',
+    },
+    isPage: true,
+  },
+} satisfies Meta<typeof DevOvhHomepage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  globals: {
+    dir: 'ltr',
+    lang: 'nl',
+  },
+};
+
+// ? Waarom hier ook nog bij globals instellen als StoryRootDecorater er is? Is dit fallback? Of nodig i.c.m. elkaar?

--- a/packages/storybook/tsconfig.json
+++ b/packages/storybook/tsconfig.json
@@ -11,6 +11,7 @@
     }
   },
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx", "config/main.ts", "config/preview.tsx", "config/Prettify.tsx"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "config/**/*.ts", "config/**/*.tsx"],
+
   "exclude": ["**/node_modules/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,10 @@ importers:
         specifier: 5.7.3
         version: 5.7.3
 
+  apps/rhc-templates/dist: {}
+
+  apps/rhc-templates/dist/types: {}
+
   packages/components-angular:
     dependencies:
       tslib:


### PR DESCRIPTION
Voor het oplossen van een A11y issue in de homepage template (ontbrekend HTML language attribuut) was ik op zoek naar een oplossing. Deze decorator waar Robbert en Matijs aan hebben gewerkt (zie links) lijkt de fix te zijn. Als we deze in het hele project implementeren, kan hij worden toegepast op iedere pagina. Meer accessibility = Meer beter. ✨ 

🔗 [paragraph.stories.tsx](https://github.com/nl-design-system/candidate/blob/51f45b518b067539c0f04ecfba7fa2e037753615/packages/storybook/stories/paragraph.stories.tsx#L42-L45)
🔗  [preview.ts](https://github.com/nl-design-system/candidate/blob/51f45b518b067539c0f04ecfba7fa2e037753615/packages/storybook/config/preview.ts#L8) 
🔗 [StoryRootDecorator](https://github.com/nl-design-system/candidate/blob/main/packages/storybook-shared/src/StoryRootDecorator.tsx)
------

⚠️ De huidige implementatie klopt nog niet. Ik heb ?comments geplaatst bij dingen die voor mij nog onduidelijk zijn.

Het gaat om de volgende files:

📁 [homepage.stories.tsx (v.a. line 20)](https://github.com/nl-design-system/rijkshuisstijl-community/pull/1587/files#diff-5832083cf87fa39e8cf551ccf10a42fd32049a3127ee5993d65c7c90fc8c6b7a) 
📁 [StoryRootDecorator.tsx](https://github.com/nl-design-system/rijkshuisstijl-community/pull/1587/files#diff-be8d2ba4504a5e1b2f06d4b1ab5f5bcc9fb8cbc730d8a6e6ea251476fbca5596)
📁 [preview.ts](https://github.com/nl-design-system/rijkshuisstijl-community/pull/1587/files#diff-73f0c209666055f8405132f28bd68572ff5e84b7be3fb5f7657210a5951c80dc)
📁 [layout.tsx](https://github.com/nl-design-system/rijkshuisstijl-community/pull/1587/files#diff-34b738e130db16014eada44cae3f44021ff9ca8b37b626ca9c487d3726d06f8c)