### PR TITLE
Github link references source code

### DIFF
--- a/packages/storybook/src/community/accordion.stories.tsx
+++ b/packages/storybook/src/community/accordion.stories.tsx
@@ -67,7 +67,8 @@ const meta = {
         component: mergeMarkdown([readme, usageDocs]),
       },
     },
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/456',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/Accordion.tsx',
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=1261-4784&p=f&t=SHnEVcZMmxKnZVS8-0',
     nldesignsystem: 'https://www.nldesignsystem.nl/accordion/',

--- a/packages/storybook/src/community/action-group.stories.tsx
+++ b/packages/storybook/src/community/action-group.stories.tsx
@@ -28,7 +28,8 @@ const meta = {
       },
     },
     nldesignsystem: 'https://www.nldesignsystem.nl/action-group/',
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/479',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/ActionGroup.tsx',
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=4626-10492&p=f&t=MHYw4lXBHCryrwek-0',
     componentOrigin:

--- a/packages/storybook/src/community/alert.stories.tsx
+++ b/packages/storybook/src/community/alert.stories.tsx
@@ -64,7 +64,8 @@ const meta = {
     },
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=1195-4201&t=n1djYpmvDCKmAEUi-0',
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/472',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/Alert.tsx',
     nldesignsystem: 'https://www.nldesignsystem.nl/alert/',
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met HTML aanpassingen en styling van de Rijkshuisstijl Community.',

--- a/packages/storybook/src/community/article.stories.tsx
+++ b/packages/storybook/src/community/article.stories.tsx
@@ -35,7 +35,8 @@ const meta = {
       },
     },
     // TODO: add Figma link
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/566',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/Article.tsx',
     nldesignsystem: 'https://www.nldesignsystem.nl/article/',
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met alleen overgeschreven design tokens van de Rijkshuisstijl Community.',

--- a/packages/storybook/src/community/blockquote.stories.tsx
+++ b/packages/storybook/src/community/blockquote.stories.tsx
@@ -40,7 +40,8 @@ const meta = {
     },
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=1349-6340&t=9KlJWkn6GEOm2sN1-11',
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/461',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/Blockquote.tsx',
     nldesignsystem: 'https://www.nldesignsystem.nl/blockquote',
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met HTML aanpassingen en styling van de Rijkshuisstijl Community.',

--- a/packages/storybook/src/community/breadcrumb-nav.stories.tsx
+++ b/packages/storybook/src/community/breadcrumb-nav.stories.tsx
@@ -25,7 +25,8 @@ const meta = {
     },
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=1862-9575&t=YSjs9i2uQ5Eq3wto-0',
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/443',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/BreadcrumbNav.tsx',
     nldesignsystem: 'https://www.nldesignsystem.nl/breadcrumb-navigation/',
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met HTML aanpassingen en styling van de Rijkshuisstijl Community.',

--- a/packages/storybook/src/community/button.stories.tsx
+++ b/packages/storybook/src/community/button.stories.tsx
@@ -104,7 +104,8 @@ const meta = {
         component: mergeMarkdown([readme, anatomyDocs, visualDesignDocs, htmlDocs, rhcReadme, wcagDocs]),
       },
     },
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/455',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/Button.tsx',
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=153-1138&p=f&t=bIUNfPQ6Tcm5rDPk-0',
     nldesignsystem: 'https://nldesignsystem.nl/button',

--- a/packages/storybook/src/community/card.stories.tsx
+++ b/packages/storybook/src/community/card.stories.tsx
@@ -99,7 +99,8 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/561',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/Card.tsx',
     figma:
       'https://www.figma.com/design/Nv5EsCW9ioWBUSi9m9JqOa/Local---Rijkshuisstijl---Bibliotheek?node-id=472-1420&p=f&t=fuaKEQHb4FZ444xP-0',
     nldesignsystem: 'https://nldesignsystem.nl/card-as-link',

--- a/packages/storybook/src/community/checkbox-group.stories.tsx
+++ b/packages/storybook/src/community/checkbox-group.stories.tsx
@@ -18,7 +18,8 @@ const meta = {
     },
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=954-2226&node-type=canvas&t=HiNKOQhf1hQtLZrr-0',
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/462',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/CheckboxGroup.tsx',
     nldesignsystem: 'https://www.nldesignsystem.nl/checkbox-group/',
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
   },

--- a/packages/storybook/src/community/checkbox.stories.tsx
+++ b/packages/storybook/src/community/checkbox.stories.tsx
@@ -23,7 +23,8 @@ const meta = {
     },
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=944-1535&node-type=canvas&t=HiNKOQhf1hQtLZrr-0',
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/462',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/Checkbox.tsx',
     nldesignsystem: 'https://www.nldesignsystem.nl/checkbox/',
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met styling van de Rijkshuisstijl Community.',

--- a/packages/storybook/src/community/code-input-group.stories.tsx
+++ b/packages/storybook/src/community/code-input-group.stories.tsx
@@ -19,7 +19,8 @@ const meta = {
     // TODO: add NL Design System link when there is a page for CodeInput
     figma:
       'https://www.figma.com/design/H4hSqpPbvFMLklDZgswwgd/NLDS---Rijkshuisstijl---Templates?node-id=4652-10195&node-type=frame&t=b4RSbycsPxEdIHZ6-0',
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/823',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/CodeInputGroup.tsx',
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
   },
   argTypes: {

--- a/packages/storybook/src/community/column-layout.stories.tsx
+++ b/packages/storybook/src/community/column-layout.stories.tsx
@@ -11,6 +11,8 @@ const meta = {
     status: { type: 'UNSTABLE' },
     docs: { description: { component: mergeMarkdown([readme]) } },
     componentOrigin: 'Dit component is overgenomen van de Gemeente Utrecht.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/ColumnLayout.tsx',
   },
   args: {
     children: '',

--- a/packages/storybook/src/community/dot-badge.stories.tsx
+++ b/packages/storybook/src/community/dot-badge.stories.tsx
@@ -26,7 +26,8 @@ const meta = {
     },
     nldesignsystem: 'https://www.nldesignsystem.nl/dot-badge',
     figma: 'https://www.figma.com/design/Nv5EsCW9ioWBUSi9m9JqOa/',
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/744',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/DotBadge.tsx',
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
   },
 } satisfies Meta<typeof DotBadge>;

--- a/packages/storybook/src/community/file-input.stories.tsx
+++ b/packages/storybook/src/community/file-input.stories.tsx
@@ -23,8 +23,10 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/FileInput.tsx',
   },
 } satisfies Meta<typeof FileInput>;
 

--- a/packages/storybook/src/community/footer.stories.tsx
+++ b/packages/storybook/src/community/footer.stories.tsx
@@ -17,7 +17,9 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/Footer.tsx',
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht (daar heeft het de naam PageFooter), met HTML aanpassingen en styling van de Rijkshuisstijl Community.',
   },

--- a/packages/storybook/src/community/form-field-checkbox-group.stories.tsx
+++ b/packages/storybook/src/community/form-field-checkbox-group.stories.tsx
@@ -64,7 +64,7 @@ const meta = {
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=954-2226&p=f&t=W7gmQ0rB1py9AmaO-0',
     github:
-      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/CheckboxGroup.tsx',
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/FormFieldCheckboxGroup.tsx',
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
   },
 } satisfies Meta<typeof FormFieldCheckboxGroup>;

--- a/packages/storybook/src/community/form-field-checkbox-option.md
+++ b/packages/storybook/src/community/form-field-checkbox-option.md
@@ -1,6 +1,6 @@
 <!-- @license CC0-1.0 -->
 
-# Rijkshuisstijl Community FormFieldCheckbox component
+# Rijkshuisstijl Community FormFieldCheckboxOption component
 
 De `FormFieldCheckboxOption` component is een uitbreidingscomponent van `FormFieldCheckbox` uit de `@utrecht/component-library-react`. Deze component voegt extra functionaliteit toe, zoals foutmeldingen met een icoon en toegankelijke beschrijvingen.
 

--- a/packages/storybook/src/community/form-field-radio-group.stories.tsx
+++ b/packages/storybook/src/community/form-field-radio-group.stories.tsx
@@ -64,6 +64,8 @@ const meta = {
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=958-1925&node-type=canvas&t=HiNKOQhf1hQtLZrr-0',
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/FormFieldRadioGroup.tsx',
   },
 } satisfies Meta<typeof FormFieldRadioGroup>;
 

--- a/packages/storybook/src/community/form-field-radio.stories.tsx
+++ b/packages/storybook/src/community/form-field-radio.stories.tsx
@@ -41,10 +41,12 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    // TODO: add GitHub issue and NL DesignSystem links
+    // TODO: add NL DesignSystem links
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=1039-2941&node-type=canvas&t=LKhOoi8eF3bD0IIP-0',
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/FormFieldRadio.tsx',
   },
 } satisfies Meta<typeof FormFieldRadio>;
 

--- a/packages/storybook/src/community/form-field-select.stories.tsx
+++ b/packages/storybook/src/community/form-field-select.stories.tsx
@@ -140,8 +140,10 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/FormFieldSelect.tsx',
   },
 } satisfies Meta<typeof FormFieldSelect>;
 

--- a/packages/storybook/src/community/form-field-text-input.stories.tsx
+++ b/packages/storybook/src/community/form-field-text-input.stories.tsx
@@ -348,9 +348,11 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht (daar heeft het de naam FormFieldTextbox), met HTML aanpassingen en styling van de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/FormFieldTextInput.tsx',
   },
 } satisfies Meta<typeof FormFieldTextInput>;
 

--- a/packages/storybook/src/community/form-field-textarea.stories.tsx
+++ b/packages/storybook/src/community/form-field-textarea.stories.tsx
@@ -229,9 +229,11 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met HTML aanpassingen en styling van de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/FormFieldTextarea.tsx',
   },
 } satisfies Meta<typeof FormFieldTextarea>;
 

--- a/packages/storybook/src/community/heading.stories.tsx
+++ b/packages/storybook/src/community/heading.stories.tsx
@@ -33,7 +33,8 @@ const meta = {
     },
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=153-1039&t=9KlJWkn6GEOm2sN1-11',
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/469',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/Heading.tsx',
     nldesignsystem: 'https://nldesignsystem.nl/heading/',
     componentOrigin:
       'Dit component is overgenomen van de NL Design System Heading Candidate met extra functionaliteit, en met overgeschreven design tokens van de Rijkshuisstijl Community.',

--- a/packages/storybook/src/community/hero.stories.tsx
+++ b/packages/storybook/src/community/hero.stories.tsx
@@ -55,7 +55,8 @@ const meta = {
     // TODO: add nldesignsystem page when it's available (not yet available on 25/03/25).
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=15708-524&node-type=canvas&t=fXG4KjJRXbo2PG2J-0',
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/466',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/Hero.tsx',
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
   },
 } satisfies Meta<typeof Hero>;

--- a/packages/storybook/src/community/icon.stories.tsx
+++ b/packages/storybook/src/community/icon.stories.tsx
@@ -26,9 +26,11 @@ const meta = {
     status: {
       type: 'STABLE',
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met extra functionaliteit voor het gebruiken van de iconenset van de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/Icon.tsx',
   },
 } satisfies Meta<typeof Icon>;
 

--- a/packages/storybook/src/community/link-list-card.stories.tsx
+++ b/packages/storybook/src/community/link-list-card.stories.tsx
@@ -40,7 +40,8 @@ const meta: Meta<StoryProps> = {
     // TODO: add NL Design System link when there is a page for LinkListCard
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=1195-4201&t=n1djYpmvDCKmAEUi-0',
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/472',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/LinkListCard.tsx',
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
   },
 };

--- a/packages/storybook/src/community/link-list-link.stories.tsx
+++ b/packages/storybook/src/community/link-list-link.stories.tsx
@@ -23,9 +23,11 @@ const meta = {
     status: {
       type: 'STABLE',
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, de design tokens kunnen indien nodig nog overschreven worden.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/LinkList.tsx',
   },
   render: (args) => (
     <LinkList>

--- a/packages/storybook/src/community/logo.stories.tsx
+++ b/packages/storybook/src/community/logo.stories.tsx
@@ -92,8 +92,10 @@ const meta = {
     status: {
       type: 'STABLE',
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/Logo.tsx',
   },
   render: LogoStory,
 } satisfies Meta<typeof LogoStory>;

--- a/packages/storybook/src/community/message-list-item.md
+++ b/packages/storybook/src/community/message-list-item.md
@@ -1,6 +1,6 @@
 <!-- @license CC0-1.0 -->
 
-# Rijkshuisstijl Community Message List component
+# Rijkshuisstijl Community Message List Item component
 
 ## Usage
 

--- a/packages/storybook/src/community/message-list-item.stories.tsx
+++ b/packages/storybook/src/community/message-list-item.stories.tsx
@@ -55,7 +55,8 @@ const meta = {
     // TODO: add NL Design System link when there is a page for MessageListItem
     figma:
       'https://www.figma.com/design/Nv5EsCW9ioWBUSi9m9JqOa/Local---Rijkshuisstijl---Bibliotheek?node-id=4070-5888&node-type=frame&t=xhXU5ugIkPqvOZwt-0',
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/556',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/MessageListItem.tsx',
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
   },
   render: (args) => {

--- a/packages/storybook/src/community/message-list.stories.tsx
+++ b/packages/storybook/src/community/message-list.stories.tsx
@@ -40,7 +40,8 @@ const meta = {
     // TODO: add NL Design System link when there is a page for MessageList
     figma:
       'https://www.figma.com/design/Nv5EsCW9ioWBUSi9m9JqOa/Local---Rijkshuisstijl---Bibliotheek?node-id=4070-5888&node-type=frame&t=xhXU5ugIkPqvOZwt-0',
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/556',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/MessageList.tsx',
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
   },
 } satisfies Meta<typeof MessageList>;

--- a/packages/storybook/src/community/navbar.md
+++ b/packages/storybook/src/community/navbar.md
@@ -1,0 +1,3 @@
+<!-- @license CC0-1.0 -->
+
+# Rijkshuisstijl Community Nav Bar component

--- a/packages/storybook/src/community/navbar.stories.tsx
+++ b/packages/storybook/src/community/navbar.stories.tsx
@@ -1,17 +1,25 @@
 import { NavBar, type NavBarItemProps } from '@rijkshuisstijl-community/components-react';
 import { Meta, StoryObj } from '@storybook/react';
+import readme from './navbar.md?raw';
+import { mergeMarkdown } from '../../helpers/merge-markdown';
 
 const meta = {
   title: 'Rijkshuisstijl/NavBar',
   id: 'rhc-nav-bar',
   component: NavBar,
   parameters: {
-    // TODO: add documentation
+    docs: {
+      description: {
+        component: mergeMarkdown([readme]),
+      },
+    },
     status: {
       type: 'UNSTABLE',
     },
     // TODO: add Figma, GitHub and NL DesignSystem links
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/NavBar.tsx',
   },
 } satisfies Meta<typeof NavBar>;
 

--- a/packages/storybook/src/community/navigation-list-item.stories.tsx
+++ b/packages/storybook/src/community/navigation-list-item.stories.tsx
@@ -23,7 +23,8 @@ const meta = {
     // TODO: add NL Design System link when there is a page for NavigationListItem
     figma:
       'https://www.figma.com/design/Nv5EsCW9ioWBUSi9m9JqOa/Local---Rijkshuisstijl---Bibliotheek?node-id=4074-1580&node-type=canvas&t=HuDzyBW9wHdB2QVh-0',
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/557',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/NavigationListItem.tsx',
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
   },
   argTypes: {

--- a/packages/storybook/src/community/navigation-list.stories.tsx
+++ b/packages/storybook/src/community/navigation-list.stories.tsx
@@ -19,7 +19,8 @@ const meta = {
     // TODO: add NL Design System link when there is a page for NavigationList
     figma:
       'https://www.figma.com/design/Nv5EsCW9ioWBUSi9m9JqOa/Local---Rijkshuisstijl---Bibliotheek?node-id=4074-1580&node-type=canvas&t=HuDzyBW9wHdB2QVh-0',
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/557',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/NavigationList.tsx',
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
   },
   argTypes: {},

--- a/packages/storybook/src/community/number-badge.stories.tsx
+++ b/packages/storybook/src/community/number-badge.stories.tsx
@@ -32,7 +32,7 @@ const meta = {
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=1233-4274&t=AHS0qWRed9fEffkN-0',
     github:
-      'https://github.com/orgs/nl-design-system/projects/59/views/1?filterQuery=badge&pane=issue&itemId=81192772&issue=nl-design-system%7Crijkshuisstijl-community%7C681',
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/NumberBadge.tsx',
   },
 } satisfies Meta<typeof NumberBadge>;
 export default meta;

--- a/packages/storybook/src/community/orderedList.stories.tsx
+++ b/packages/storybook/src/community/orderedList.stories.tsx
@@ -22,6 +22,9 @@ const meta = {
     },
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met styling van de Rijkshuisstijl Community.',
+    // TODO: add NL Design System link and Figma link
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/OrderedList.tsx',
   },
 } satisfies Meta<typeof OrderedList>;
 

--- a/packages/storybook/src/community/orderedListItem.md
+++ b/packages/storybook/src/community/orderedListItem.md
@@ -1,0 +1,1 @@
+# Rijkshuisstijl Community ordered list item component

--- a/packages/storybook/src/community/orderedListItem.stories.tsx
+++ b/packages/storybook/src/community/orderedListItem.stories.tsx
@@ -1,8 +1,10 @@
 import { OrderedList, OrderedListItem } from '@rijkshuisstijl-community/components-react';
 import { Meta, StoryObj } from '@storybook/react';
+import readme from './orderedListItem.md?raw';
+import { mergeMarkdown } from '../../helpers/merge-markdown';
 
 const meta = {
-  title: 'Rijkshuisstijl/Ordered List/Ordered Item',
+  title: 'Rijkshuisstijl/Ordered List/Ordered List Item',
   id: 'rhc-ordered-list-item',
   component: OrderedListItem,
   decorators: [(Story) => <OrderedList>{Story()}</OrderedList>],
@@ -18,12 +20,18 @@ const meta = {
     },
   },
   parameters: {
-    // TODO: add documentation, but not until readme is correctly structurized in the Utrecht documentation source
+    docs: {
+      description: {
+        component: mergeMarkdown([readme]),
+      },
+    },
     status: {
       type: 'STABLE',
     },
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met styling van de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/OrderedList.tsx',
   },
 } satisfies Meta<typeof OrderedListItem>;
 

--- a/packages/storybook/src/community/page-header.stories.tsx
+++ b/packages/storybook/src/community/page-header.stories.tsx
@@ -18,9 +18,11 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, voor dit component zijn (nog) geen specifieke design tokens gedefinieerd.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/PageHeader.tsx',
   },
 } satisfies Meta<typeof PageHeader>;
 

--- a/packages/storybook/src/community/paragraph.stories.tsx
+++ b/packages/storybook/src/community/paragraph.stories.tsx
@@ -54,9 +54,11 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met alleen overgeschreven design tokens van de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/Paragraph.tsx',
   },
 } as Meta<typeof Paragraph>;
 

--- a/packages/storybook/src/community/pre-heading.stories.tsx
+++ b/packages/storybook/src/community/pre-heading.stories.tsx
@@ -20,9 +20,11 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met HTML aanpassingen en styling van de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/PreHeading.tsx',
   },
 } satisfies Meta<typeof PreHeading>;
 

--- a/packages/storybook/src/community/radio-group.stories.tsx
+++ b/packages/storybook/src/community/radio-group.stories.tsx
@@ -2,6 +2,8 @@ import '@rijkshuisstijl-community/components-css/index.scss';
 
 import { FormFieldRadio } from '@rijkshuisstijl-community/components-react';
 import type { Meta, StoryObj } from '@storybook/react';
+import readme from './radio-group.md?raw';
+import { mergeMarkdown } from '../../helpers/merge-markdown';
 
 const RadioGroupStory = () => (
   <div className="rhc-radio-group">
@@ -18,12 +20,18 @@ const meta = {
   component: RadioGroupStory,
   render: RadioGroupStory,
   parameters: {
-    // TODO: add documentation
+    docs: {
+      description: {
+        component: mergeMarkdown([readme]),
+      },
+    },
     status: {
       type: 'STABLE',
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/RadioGroup.tsx',
   },
 } satisfies Meta<typeof RadioGroupStory>;
 

--- a/packages/storybook/src/community/radio.stories.tsx
+++ b/packages/storybook/src/community/radio.stories.tsx
@@ -93,9 +93,11 @@ const meta = {
         component: mergeMarkdown([readme, anatomyDocs, visualDesignDocs]),
       },
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
     componentOrigin:
       'Dit component en de documentatie hieronder is overgenomen van de Gemeente Utrecht (daar heeft het de naam RadioButton), met styling van de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/Radio.tsx',
   },
 } satisfies Meta<typeof RadioStory>;
 

--- a/packages/storybook/src/community/separator.stories.tsx
+++ b/packages/storybook/src/community/separator.stories.tsx
@@ -17,9 +17,11 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met HTML aanpassingen en styling van de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/Separator.tsx',
   },
   argTypes: {
     invisible: {

--- a/packages/storybook/src/community/side-nav-link.stories.tsx
+++ b/packages/storybook/src/community/side-nav-link.stories.tsx
@@ -43,8 +43,10 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/SideNavLink.tsx',
   },
 } satisfies Meta<typeof SideNavLink>;
 export default meta;

--- a/packages/storybook/src/community/side-nav.stories.tsx
+++ b/packages/storybook/src/community/side-nav.stories.tsx
@@ -25,8 +25,10 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/SideNav.tsx',
   },
 } satisfies Meta<typeof SideNav>;
 export default meta;

--- a/packages/storybook/src/community/skip-link.stories.tsx
+++ b/packages/storybook/src/community/skip-link.stories.tsx
@@ -84,6 +84,10 @@ export const Default: Story = {
         story: `Styling met de \`.rhc-skip-link\` en \`.rhc-skip-link--visible-on-focus\` class naam.`,
       },
     },
+    // TODO: add Figma and NL DesignSystem links
+    componentOrigin: 'Dit component is overgenomen vanuit de NL-Design system candidate repo.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/SkipLink.tsx',
   },
 };
 

--- a/packages/storybook/src/community/table-cell.stories.tsx
+++ b/packages/storybook/src/community/table-cell.stories.tsx
@@ -47,7 +47,8 @@ export default {
     },
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=1561-6448&t=texUKkpCqzgFVuch-0',
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/465',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/TableCell.tsx',
     nldesignsystem: 'https://www.nldesignsystem.nl/table/',
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met HTML aanpassingen en styling van de Rijkshuisstijl Community.',

--- a/packages/storybook/src/community/table-header-cell.stories.tsx
+++ b/packages/storybook/src/community/table-header-cell.stories.tsx
@@ -58,7 +58,8 @@ const meta = {
     },
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=1561-6448&t=texUKkpCqzgFVuch-0',
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/465',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/TableHeaderCell.tsx',
     nldesignsystem: 'https://www.nldesignsystem.nl/table/',
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met HTML aanpassingen en styling van de Rijkshuisstijl Community.',

--- a/packages/storybook/src/community/table.stories.tsx
+++ b/packages/storybook/src/community/table.stories.tsx
@@ -33,7 +33,8 @@ const meta = {
     },
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=1561-6448&t=texUKkpCqzgFVuch-0',
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/465',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/Table.tsx',
     nldesignsystem: 'https://www.nldesignsystem.nl/table/',
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met styling van de Rijkshuisstijl Community.',

--- a/packages/storybook/src/community/text-input.stories.tsx
+++ b/packages/storybook/src/community/text-input.stories.tsx
@@ -258,6 +258,8 @@ const meta: Meta<typeof TextInput> = {
     nldesignsystem: 'https://www.nldesignsystem.nl/text-input/',
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht (daar heet het Textbox), met styling van de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/TextInput.tsx',
   },
   render: (args) => {
     const {

--- a/packages/storybook/src/community/textarea.stories.tsx
+++ b/packages/storybook/src/community/textarea.stories.tsx
@@ -188,12 +188,13 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    // TODO: add Github issue link
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=969-2047&node-type=CANVAS&t=VGu5hA1sXPDhCUwB-0',
     nldesignsystem: 'https://www.nldesignsystem.nl/textarea/',
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met styling van de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/Textarea.tsx',
   },
 } satisfies Meta<typeof Textarea>;
 

--- a/packages/storybook/src/community/toggletip.md
+++ b/packages/storybook/src/community/toggletip.md
@@ -1,0 +1,3 @@
+<!-- @license CC0-1.0 -->
+
+# Rijkshuisstijl Community Toggle Tip component

--- a/packages/storybook/src/community/toggletip.stories.tsx
+++ b/packages/storybook/src/community/toggletip.stories.tsx
@@ -1,5 +1,7 @@
 import { Toggletip } from '@rijkshuisstijl-community/components-react';
 import { Meta, StoryObj } from '@storybook/react';
+import readme from './toggletip.md?raw';
+import { mergeMarkdown } from '../../helpers/merge-markdown';
 
 const meta = {
   title: 'Rijkshuisstijl/Toggletip',
@@ -9,12 +11,18 @@ const meta = {
     children: 'Lorem ipsum dolor sit amet, consecteur ad * isicing elit, sed do eiusmod *',
   },
   parameters: {
-    // TODO: add documentation
+    docs: {
+      description: {
+        component: mergeMarkdown([readme]),
+      },
+    },
     status: {
       type: 'UNSTABLE',
     },
     // TODO: add Figma, GitHub and NL DesignSystem links
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/Toggletip.tsx',
   },
 } satisfies Meta<typeof Toggletip>;
 

--- a/packages/storybook/src/community/unorderedList.stories.tsx
+++ b/packages/storybook/src/community/unorderedList.stories.tsx
@@ -23,6 +23,8 @@ const meta = {
     // TODO: add Figma, GitHub and NL DesignSystem links
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met HTML aanpassingen en styling van de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/UnorderedList.tsx',
   },
 } satisfies Meta<typeof UnorderedList>;
 

--- a/packages/storybook/src/community/unorderedListItem.md
+++ b/packages/storybook/src/community/unorderedListItem.md
@@ -1,0 +1,1 @@
+# Rijkshuisstijl Community unordered list item component

--- a/packages/storybook/src/community/unorderedListItem.stories.tsx
+++ b/packages/storybook/src/community/unorderedListItem.stories.tsx
@@ -1,8 +1,10 @@
 import { UnorderedList, UnorderedListItem } from '@rijkshuisstijl-community/components-react';
 import { Meta, StoryObj } from '@storybook/react/*';
+import readme from './unorderedListItem.md?raw';
+import { mergeMarkdown } from '../../helpers/merge-markdown';
 
 const meta = {
-  title: 'Rijkshuisstijl/Unordered List/Unordered Item',
+  title: 'Rijkshuisstijl/Unordered List/Unordered List Item',
   id: 'rhc-unorderedListItem',
   component: UnorderedListItem,
   decorators: [(Story) => <UnorderedList>{Story()}</UnorderedList>],
@@ -10,13 +12,19 @@ const meta = {
     children: 'List item',
   },
   parameters: {
-    // TODO: add documentation
+    docs: {
+      description: {
+        component: mergeMarkdown([readme]),
+      },
+    },
     status: {
       type: 'STABLE',
     },
     // TODO: add Figma, GitHub and NL DesignSystem links
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met styling van de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/UnorderedListItem.tsx',
   },
 } satisfies Meta<typeof UnorderedListItem>;
 

--- a/packages/storybook/src/components-twig/alert-twig.stories.tsx
+++ b/packages/storybook/src/components-twig/alert-twig.stories.tsx
@@ -64,6 +64,8 @@ const meta = {
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=1195-4201&t=n1djYpmvDCKmAEUi-0',
     nldesignsystem: 'https://www.nldesignsystem.nl/alert/',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-twig/src/Alert.twig',
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
   },
 } satisfies Meta<typeof TwigAlert>;

--- a/packages/storybook/src/components-twig/heading-twig.stories.tsx
+++ b/packages/storybook/src/components-twig/heading-twig.stories.tsx
@@ -32,6 +32,9 @@ const meta = {
       },
     },
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
+    //Todo: voeg NL-Design system & Figma links toe
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-twig/src/Heading.twig',
   },
 } satisfies Meta<typeof TwigHeading>;
 

--- a/packages/storybook/src/components-twig/icon-twig.stories.tsx
+++ b/packages/storybook/src/components-twig/icon-twig.stories.tsx
@@ -31,6 +31,9 @@ const meta = {
     status: {
       type: 'STABLE',
     },
+    //Todo: voeg NL-Design system & Figma links toe
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-twig/src/Icon.twig',
   },
 } satisfies Meta<typeof TwigIcon>;
 

--- a/packages/storybook/src/components-twig/image-twig.stories.tsx
+++ b/packages/storybook/src/components-twig/image-twig.stories.tsx
@@ -55,6 +55,9 @@ const meta = {
     },
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, maar de photo property altijd geset, daardoor is hij altijd max-height en max-width 100%.',
+    //Todo: voeg NL-Design system & Figma links toe
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-twig/src/Image.twig',
   },
 } satisfies Meta<typeof TwigImage>;
 

--- a/packages/storybook/src/components-twig/paragraph-twig.stories.tsx
+++ b/packages/storybook/src/components-twig/paragraph-twig.stories.tsx
@@ -55,6 +55,9 @@ const meta = {
       },
     },
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
+    //Todo: voeg NL-Design system & Figma links toe
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-twig/src/Paragraph.twig',
   },
 } satisfies Meta<typeof TwigParagraph>;
 

--- a/packages/storybook/src/web-components/accordion.stories.tsx
+++ b/packages/storybook/src/web-components/accordion.stories.tsx
@@ -70,9 +70,11 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met styling van de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/web-components/src/components/Accordion.tsx',
   },
 } as Meta<AccordionWebComponentAttributes>;
 

--- a/packages/storybook/src/web-components/action-group.stories.tsx
+++ b/packages/storybook/src/web-components/action-group.stories.tsx
@@ -32,9 +32,11 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht (daar heeft het de naam ButtonGroup), met styling van de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/web-components/src/components/ActionGroup.tsx',
   },
 } as Meta<typeof ActionGroupWebComponent>;
 

--- a/packages/storybook/src/web-components/alert.stories.tsx
+++ b/packages/storybook/src/web-components/alert.stories.tsx
@@ -66,7 +66,8 @@ const meta = {
     },
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=1195-4201&t=n1djYpmvDCKmAEUi-0',
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/472',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/web-components/src/components/Alert.tsx',
     nldesignsystem: 'https://www.nldesignsystem.nl/alert/',
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met HTML aanpassingen en styling van de Rijkshuisstijl Community.',

--- a/packages/storybook/src/web-components/article.stories.tsx
+++ b/packages/storybook/src/web-components/article.stories.tsx
@@ -37,7 +37,8 @@ const meta = {
       },
     },
     // TODO: add Figma link
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/566',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/web-components/src/components/Article.tsx',
     nldesignsystem: 'https://www.nldesignsystem.nl/article/',
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met alleen overgeschreven design tokens van de Rijkshuisstijl Community.',

--- a/packages/storybook/src/web-components/blockquote.stories.tsx
+++ b/packages/storybook/src/web-components/blockquote.stories.tsx
@@ -40,7 +40,8 @@ const meta = {
     },
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=1349-6340&t=9KlJWkn6GEOm2sN1-11',
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/461',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/web-components/src/components/Blockquote.tsx',
     nldesignsystem: 'https://www.nldesignsystem.nl/blockquote',
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met HTML aanpassingen en styling van de Rijkshuisstijl Community.',

--- a/packages/storybook/src/web-components/breadcrumb-nav.stories.tsx
+++ b/packages/storybook/src/web-components/breadcrumb-nav.stories.tsx
@@ -29,7 +29,8 @@ const meta = {
     },
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=1862-9575&t=YSjs9i2uQ5Eq3wto-0',
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/443',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/web-components/src/components/BreadcrumbNav.tsx',
     nldesignsystem: 'https://www.nldesignsystem.nl/breadcrumb-navigation/',
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met HTML aanpassingen en styling van de Rijkshuisstijl Community.',

--- a/packages/storybook/src/web-components/button.stories.tsx
+++ b/packages/storybook/src/web-components/button.stories.tsx
@@ -52,9 +52,11 @@ const meta = {
         component: mergeMarkdown([readme, anatomyDocs, visualDesignDocs, htmlDocs, wcagDocs]),
       },
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met HTML aanpassingen (voor de IconButton) en styling van de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/web-components/src/components/Button.tsx',
   },
 } as Meta<typeof ButtonWebComponent>;
 

--- a/packages/storybook/src/web-components/card.stories.tsx
+++ b/packages/storybook/src/web-components/card.stories.tsx
@@ -108,7 +108,8 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/561',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/web-components/src/components/Card.tsx',
     figma:
       'https://www.figma.com/design/Nv5EsCW9ioWBUSi9m9JqOa/Local---Rijkshuisstijl---Bibliotheek?node-id=472-1420&p=f&t=fuaKEQHb4FZ444xP-0',
     nldesignsystem: 'https://nldesignsystem.nl/card-as-link',

--- a/packages/storybook/src/web-components/checkbox-group.stories.tsx
+++ b/packages/storybook/src/web-components/checkbox-group.stories.tsx
@@ -25,7 +25,8 @@ const meta = {
     },
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=954-2226&node-type=canvas&t=HiNKOQhf1hQtLZrr-0',
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/462',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/web-components/src/components/CheckboxGroup.tsx',
     nldesignsystem: 'https://www.nldesignsystem.nl/checkbox-group/',
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
   },

--- a/packages/storybook/src/web-components/checkbox.stories.tsx
+++ b/packages/storybook/src/web-components/checkbox.stories.tsx
@@ -46,7 +46,8 @@ const meta = {
     },
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=944-1535&node-type=canvas&t=HiNKOQhf1hQtLZrr-0',
-    github: 'https://github.com/nl-design-system/rijkshuisstijl-community/issues/462',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/web-components/src/components/Checkbox.tsx',
     nldesignsystem: 'https://www.nldesignsystem.nl/checkbox/',
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met styling van de Rijkshuisstijl Community.',

--- a/packages/storybook/src/web-components/form-field-checkbox-group.stories.tsx
+++ b/packages/storybook/src/web-components/form-field-checkbox-group.stories.tsx
@@ -79,10 +79,12 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    // TODO: add GitHub issue and NL DesignSystem links
+    // TODO: add NL DesignSystem link
     figma:
       '(https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=958-1925&node-type=canvas&t=HiNKOQhf1hQtLZrr-0',
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/web-components/src/components/FormFieldCheckboxGroup.tsx',
   },
 } as Meta<typeof FormFieldCheckboxGroupWebComponent>;
 

--- a/packages/storybook/src/web-components/form-field-checkbox-option.stories.tsx
+++ b/packages/storybook/src/web-components/form-field-checkbox-option.stories.tsx
@@ -99,11 +99,13 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    // TODO: add GitHub issue and NL DesignSystem links
+    // TODO: add NL DesignSystem link
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=1031-2917&node-type=canvas&t=HiNKOQhf1hQtLZrr-0',
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht (daar heet het FormFieldCheckbox), met HTML aanpassingen en styling van de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/web-components/src/components/FormFieldCheckboxOption.tsx',
   },
 } as Meta<typeof FormFieldCheckboxOptionWebComponent>;
 

--- a/packages/storybook/src/web-components/form-field-radio-group.stories.tsx
+++ b/packages/storybook/src/web-components/form-field-radio-group.stories.tsx
@@ -82,10 +82,12 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    // TODO: add GitHub issue and NL DesignSystem links
+    // TODO: add and NL DesignSystem link
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=958-1925&node-type=canvas&t=HiNKOQhf1hQtLZrr-0',
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/web-components/src/components/FormFieldRadioGroup.tsx',
   },
 } as Meta<typeof FormFieldRadioWebComponent>;
 

--- a/packages/storybook/src/web-components/form-field-radio.stories.tsx
+++ b/packages/storybook/src/web-components/form-field-radio.stories.tsx
@@ -66,10 +66,12 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    // TODO: add GitHub issue and NL DesignSystem links
+    // TODO: add NL DesignSystem link
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=1039-2941&node-type=canvas&t=LKhOoi8eF3bD0IIP-0',
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/web-components/src/components/FormFieldRadio.tsx',
   },
 } as Meta<typeof FormFieldRadioWebComponent>;
 

--- a/packages/storybook/src/web-components/form-field-select.stories.tsx
+++ b/packages/storybook/src/web-components/form-field-select.stories.tsx
@@ -132,8 +132,10 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/web-components/src/components/FormFieldSelect.tsx',
   },
 } as Meta<typeof FormFieldSelectWebComponent>;
 

--- a/packages/storybook/src/web-components/form-field-text-input.stories.tsx
+++ b/packages/storybook/src/web-components/form-field-text-input.stories.tsx
@@ -325,9 +325,11 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht (daar heeft het de naam FormFieldTextbox), met HTML aanpassingen en styling van de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/web-components/src/components/FormFieldTextInput.tsx',
   },
 } as Meta<typeof FormFieldTextInputWebComponent>;
 

--- a/packages/storybook/src/web-components/form-field-textarea.stories.tsx
+++ b/packages/storybook/src/web-components/form-field-textarea.stories.tsx
@@ -206,9 +206,11 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met HTML aanpassingen en styling van de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/web-components/src/components/FormFieldTextarea.tsx',
   },
 } as Meta<typeof FormFieldTextareaWebComponent>;
 

--- a/packages/storybook/src/web-components/hero.stories.tsx
+++ b/packages/storybook/src/web-components/hero.stories.tsx
@@ -103,10 +103,12 @@ const meta = {
         component: mergeMarkdown([readme]),
       },
     },
-    // TODO: add GitHub issue and NL DesignSystem links
+    // TODO: add NL DesignSystem link
     figma:
       'https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?node-id=15708-524&node-type=canvas&t=fXG4KjJRXbo2PG2J-0',
     componentOrigin: 'Dit component is volledig ontwikkeld door de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/web-components/src/components/Hero.tsx',
   },
 } as Meta<typeof HeroWebComponent>;
 

--- a/packages/storybook/src/web-components/icon.stories.tsx
+++ b/packages/storybook/src/web-components/icon.stories.tsx
@@ -30,9 +30,11 @@ const meta = {
     status: {
       type: 'STABLE',
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met extra functionaliteit voor het gebruiken van de iconenset van de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/web-components/src/components/Icon.tsx',
   },
 } as Meta<typeof IconWebComponent>;
 

--- a/packages/storybook/src/web-components/link.stories.tsx
+++ b/packages/storybook/src/web-components/link.stories.tsx
@@ -109,9 +109,11 @@ const meta = {
         ]),
       },
     },
-    // TODO: add Figma, GitHub and NL DesignSystem links
+    // TODO: add Figma and NL DesignSystem links
     componentOrigin:
       'Dit component is overgenomen van de Gemeente Utrecht, met HTML aanpassingen en styling van de Rijkshuisstijl Community.',
+    github:
+      'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/web-components/src/components/Link.tsx',
   },
   render: LinkWrapper,
 } as Meta<typeof LinkWebComponent>;


### PR DESCRIPTION
Deze PR heeft uiteindelijk heel veel files aangeraakt, dus hier een beschrijving van wat ik gedaan heb:
- Alle Github links refereren nu naar de source code ipv het issue
- Waar nog geen GitHub links waren heb ik die toegevoegd
- Ik heb de Todo's aangepast van welke links er nog nodig zijn in stories om rekening te houden met eventuele toegevoegde GitHub links 
- Ik heb Todo's van links toegevoegd, waar de links incompleet waren en er nog geen todo was
- Ik heb waar geen docs (in de vorm van een `.md` file) waren, een md file toegevoegd met alleen een titel, zodat elke component docs pagina een titel heeft. In deze gevallen heb ik ook de `todo: add docs` verwijderd
- Ik heb titels aangepast die volgens mij niet compleet waren
- Ik heb [https://rijkshuisstijl-community.vercel.app/?path=/docs/rhc-twig-ordered-list--docs genegeerd, omdat er stond dat dat een dummy component is
- 
Dit gaat om de `storybook/community`, `storybook/twig`

Closes #1607 