### PR TITLE
chore: update Dependabot configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Changes to this file (.github/CODEOWNERS) require approval from @nl-design-system/kernteam-admin
+.github/CODEOWNERS @nl-design-system/kernteam-admin

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    reviewers:
-      - "nl-design-system/kernteam-dependabot"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -17,5 +15,3 @@ updates:
           - "version-update:semver-major"
     versioning-strategy: "increase-if-necessary"
     open-pull-requests-limit: 20
-    reviewers:
-      - "nl-design-system/kernteam-dependabot"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      patch-and-minor-dependencies:
+        applies-to: "version-updates"
+        update-types:
+          - "patch"
+          - "minor"
     ignore:
       - dependency-name: "@types/node"
         update-types:


### PR DESCRIPTION
See: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

- Remove "reviewers" from `.github/dependabot.yml`
- Add basic `.github/CODEOWNERS`

Group Dependabot updates to bring down the number of pull requests to a more manageable level.

We still should not actually merge these Dependabot pull requests as they merely serve as a reminder we need to keep on top of dependency updates.