### PR TITLE
feat: update utrecht component-library-css and component-library-react

### DIFF
--- a/.changeset/small-news-lose.md
+++ b/.changeset/small-news-lose.md
@@ -1,0 +1,6 @@
+---
+'@rijkshuisstijl-community/components-react': minor
+'@rijkshuisstijl-community/components-css': minor
+---
+
+Update dependencies.

--- a/packages/components-css/package.json
+++ b/packages/components-css/package.json
@@ -34,6 +34,6 @@
     "@nl-design-system-candidate/number-badge-css": "1.1.2",
     "@nl-design-system-candidate/paragraph-css": "2.1.0",
     "@nl-design-system-candidate/skip-link-css": "1.0.2",
-    "@utrecht/component-library-css": "7.1.5"
+    "@utrecht/component-library-css": "7.2.1"
   }
 }

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -56,7 +56,7 @@
     "@types/jest": "29.5.14",
     "@types/lodash.chunk": "4.2.9",
     "@types/react": "19.0.10",
-    "@utrecht/component-library-react": "9.0.6",
+    "@utrecht/component-library-react": "10.1.0",
     "@utrecht/link-react": "1.0.6",
     "@utrecht/radio-button-react": "1.0.6",
     "@vitejs/plugin-react": "4.4.1",

--- a/packages/components-react/src/Alert.test.tsx
+++ b/packages/components-react/src/Alert.test.tsx
@@ -15,23 +15,23 @@ describe('Alert', () => {
     const alert = container.querySelector('.rhc-alert');
     expect(alert).toBeInTheDocument();
   });
+
+  test.each([['info'], ['ok'], ['warning'], ['error']])(
+    'should apply the correct class based on the type prop: %s',
+    (type) => {
+      const { container } = render(
+        <Alert heading="Test Heading" textContent="Test content" type={type as 'info' | 'ok' | 'warning' | 'error'} />,
+      );
+
+      const alert = container.querySelector('.rhc-alert');
+      const iconContainer = alert?.querySelector('.rhc-alert__icon-container');
+
+      expect(iconContainer).toHaveClass(`rhc-alert__icon-container`);
+      expect(iconContainer).toHaveClass(`rhc-alert__icon-container--${type}`);
+
+      cleanup();
+    },
+  );
+
+  afterEach(() => cleanup());
 });
-
-test.each([['info'], ['ok'], ['warning'], ['error']])(
-  'should apply the correct class based on the type prop: %s',
-  (type) => {
-    const { container } = render(
-      <Alert heading="Test Heading" textContent="Test content" type={type as 'info' | 'ok' | 'warning' | 'error'} />,
-    );
-
-    const alert = container.querySelector('.rhc-alert');
-    const iconContainer = alert?.querySelector('.rhc-alert__icon-container');
-
-    expect(iconContainer).toHaveClass(`rhc-alert__icon-container`);
-    expect(iconContainer).toHaveClass(`rhc-alert__icon-container--${type}`);
-
-    cleanup();
-  },
-);
-
-afterEach(() => cleanup());

--- a/packages/components-react/src/Alert.test.tsx
+++ b/packages/components-react/src/Alert.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest';
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, test } from 'vitest';
 import { Alert } from './Alert';
 
@@ -14,6 +14,24 @@ describe('Alert', () => {
     );
     const alert = container.querySelector('.rhc-alert');
     expect(alert).toBeInTheDocument();
+  });
+
+  it.each([
+    ['info', 'status'],
+    ['ok', 'status'],
+    ['warning', 'alert'],
+    ['error', 'alert'],
+  ])('should set role="%s" when type is %s', (type, expectedRole) => {
+    render(
+      <Alert
+        heading="Heading"
+        textContent="Lorem ipsum dolor sit amet, consectetur ad * isicing elit, sed do eiusmod *"
+        type={type as 'info' | 'ok' | 'warning' | 'error'}
+      />,
+    );
+    const alert = screen.getByRole(expectedRole);
+    expect(alert).toBeInTheDocument();
+    cleanup();
   });
 
   test.each([['info'], ['ok'], ['warning'], ['error']])(

--- a/packages/components-react/src/Alert.test.tsx
+++ b/packages/components-react/src/Alert.test.tsx
@@ -1,18 +1,18 @@
 import '@testing-library/jest-dom/vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, render } from '@testing-library/react';
 import { afterEach, describe, expect, it, test } from 'vitest';
 import { Alert } from './Alert';
 
 describe('Alert', () => {
   it('should render successfully', () => {
-    render(
+    const { container } = render(
       <Alert
         heading="Heading"
         textContent="Lorem ipsum dolor sit amet, consectetur ad * isicing elit, sed do eiusmod *"
         type="info"
       />,
     );
-    const alert = screen.getByRole('alert');
+    const alert = container.querySelector('.rhc-alert');
     expect(alert).toBeInTheDocument();
   });
 });
@@ -20,12 +20,12 @@ describe('Alert', () => {
 test.each([['info'], ['ok'], ['warning'], ['error']])(
   'should apply the correct class based on the type prop: %s',
   (type) => {
-    render(
+    const { container } = render(
       <Alert heading="Test Heading" textContent="Test content" type={type as 'info' | 'ok' | 'warning' | 'error'} />,
     );
 
-    const alert = screen.getByRole('alert');
-    const iconContainer = alert.querySelector('.rhc-alert__icon-container');
+    const alert = container.querySelector('.rhc-alert');
+    const iconContainer = alert?.querySelector('.rhc-alert__icon-container');
 
     expect(iconContainer).toHaveClass(`rhc-alert__icon-container`);
     expect(iconContainer).toHaveClass(`rhc-alert__icon-container--${type}`);

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -63,7 +63,7 @@
     "@types/react": "19.0.10",
     "@types/react-dom": "19.1.0",
     "@types/twig": "1.12.16",
-    "@utrecht/component-library-react": "9.0.6",
+    "@utrecht/component-library-react": "10.1.0",
     "@utrecht/components": "7.4.0",
     "@utrecht/page-body-react": "1.0.5",
     "@utrecht/page-layout-react": "1.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,7 +107,7 @@ importers:
     dependencies:
       next:
         specifier: 15.2.0
-        version: 15.2.0(@babel/core@7.27.1)(@playwright/test@1.52.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.87.0)
+        version: 15.2.0(@playwright/test@1.52.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.87.0)
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -172,7 +172,7 @@ importers:
     dependencies:
       '@angular-devkit/build-angular':
         specifier: 19.2.0
-        version: 19.2.0(@angular/compiler-cli@19.2.0(@angular/compiler@19.2.0(@angular/core@19.2.0(rxjs@7.8.0)(zone.js@0.15.0)))(typescript@5.7.2))(@angular/compiler@19.2.0(@angular/core@19.2.0(rxjs@7.8.0)(zone.js@0.15.0)))(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@20.17.6)(chokidar@4.0.1)(html-webpack-plugin@5.6.3(webpack@5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))))(jest-environment-jsdom@29.7.0)(jest@29.7.0(@types/node@20.17.6))(jiti@1.21.7)(karma@6.4.0)(ng-packagr@19.2.0(@angular/compiler-cli@19.2.0(@angular/compiler@19.2.0(@angular/core@19.2.0(rxjs@7.8.0)(zone.js@0.15.0)))(typescript@5.7.2))(tslib@2.3.0)(typescript@5.7.2))(typescript@5.7.2)(vite@6.1.0(@types/node@20.17.6)(jiti@1.21.7)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(yaml@2.7.0))(yaml@2.7.0)
+        version: 19.2.0(@angular/compiler-cli@19.2.0(@angular/compiler@19.2.0(@angular/core@19.2.0(rxjs@7.8.0)(zone.js@0.15.0)))(typescript@5.7.2))(@angular/compiler@19.2.0(@angular/core@19.2.0(rxjs@7.8.0)(zone.js@0.15.0)))(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@20.17.6)(chokidar@4.0.1)(html-webpack-plugin@5.6.3(webpack@5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.0)))(jest-environment-jsdom@29.7.0)(jest@29.7.0(@types/node@20.17.6))(jiti@1.21.7)(karma@6.4.0)(ng-packagr@19.2.0(@angular/compiler-cli@19.2.0(@angular/compiler@19.2.0(@angular/core@19.2.0(rxjs@7.8.0)(zone.js@0.15.0)))(typescript@5.7.2))(tslib@2.3.0)(typescript@5.7.2))(typescript@5.7.2)(vite@6.1.0(@types/node@20.17.6)(jiti@1.21.7)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(yaml@2.7.0))(yaml@2.7.0)
       '@angular/cli':
         specifier: 19.2.3
         version: 19.2.3(@types/node@20.17.6)(chokidar@4.0.1)
@@ -265,8 +265,8 @@ importers:
         specifier: 1.0.2
         version: 1.0.2
       '@utrecht/component-library-css':
-        specifier: 7.1.5
-        version: 7.1.5
+        specifier: 7.2.1
+        version: 7.2.1
     devDependencies:
       scss:
         specifier: 0.2.4
@@ -348,8 +348,8 @@ importers:
         specifier: 19.0.10
         version: 19.0.10
       '@utrecht/component-library-react':
-        specifier: 9.0.6
-        version: 9.0.6(@babel/runtime@7.27.1)(date-fns@2.30.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 10.1.0
+        version: 10.1.0(@babel/runtime@7.27.1)(date-fns@2.30.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@utrecht/link-react':
         specifier: 1.0.6
         version: 1.0.6(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -575,8 +575,8 @@ importers:
         specifier: 1.12.16
         version: 1.12.16
       '@utrecht/component-library-react':
-        specifier: 9.0.6
-        version: 9.0.6(@babel/runtime@7.27.1)(date-fns@2.30.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 10.1.0
+        version: 10.1.0(@babel/runtime@7.27.1)(date-fns@2.30.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@utrecht/components':
         specifier: 7.4.0
         version: 7.4.0
@@ -5643,38 +5643,35 @@ packages:
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
-  '@utrecht/accordion-css@1.6.0':
-    resolution: {integrity: sha512-0PLGWCgRvFyR8kINBE4v8dsQxxdfKbmC5oEolOF2jGJ7NlmeTE29ODAzlcqwiocWOjM45jgXDK8aRVAle2DObg==}
+  '@utrecht/accordion-css@2.0.0':
+    resolution: {integrity: sha512-U+NI6SXu5ULPjD+UDrdjh9f5AY+Hc3h5gIaqisDkogvmEDX7lkdOVxby0PrkBcVkEuiq9AIg9/RT0U3uFc7vwg==}
 
-  '@utrecht/alert-css@2.2.0':
-    resolution: {integrity: sha512-cCJngxahyzpQyCNEr7i1PcNI0g2Ez++Uy2roaRKW6E5bFZO3srriODr+0rmhAEhij4inS9cf5D9QbhhMjMjsww==}
+  '@utrecht/alert-css@2.3.0':
+    resolution: {integrity: sha512-ATN820rMOASAJkkELuFqRW5hBO7WBxCd+yEFpIsLlm3ptTTnwOWl0MIBN3zNpgne3UM6U5R1YxSQwJ1FA0hEdA==}
 
-  '@utrecht/alert-dialog-css@1.4.1':
-    resolution: {integrity: sha512-/qU7389DpIyKcfiTFNIBwf2UiWieXEbJpdWHgdsHdMm//X0Eu5XVyack02bSA02zt5En7gmm2RfRixH2U56Ltg==}
+  '@utrecht/alert-dialog-css@1.4.2':
+    resolution: {integrity: sha512-fnL692KHBh3POeyu9IxOjbZ/9Alb/ppjbt+uQ0ukyfhd8NUS9BYmwJTr9j5LUZdg9Kep/nHMbAN1zSptQ0DICQ==}
 
-  '@utrecht/alternate-lang-nav-css@1.3.0':
-    resolution: {integrity: sha512-SgIcDv+f/62SYFC7otbF4K4MIzhQYX6FIJBH69xJpDGEYrVpBnDDOQD7OkH9XVeCmFYvZ8pfx/RGYvVQeBtlug==}
+  '@utrecht/alternate-lang-nav-css@1.3.1':
+    resolution: {integrity: sha512-MY0qHM+tt1Q9v6SG+lTzDNh3xNs0eO9lpvzUWbwpR7z0fmRq/65+gYhZwFCiAKaWou+A1Uog082V0fSTslNkKw==}
 
-  '@utrecht/article-css@1.5.0':
-    resolution: {integrity: sha512-WiWVmu46TdSQTlLLNJQhYH1L2D75dMILXhpDt8xS04HdSlsmiuTAL0zG6p5DR83t0QEeKlOUvoZMPLQ9SGGlSg==}
+  '@utrecht/article-css@1.5.1':
+    resolution: {integrity: sha512-zCRB9L0BTXCYmwNLI6NGlfds4+heXji4yEo79dF/t2O3xGGbMA1hy1zI20Plf6z36P9gnONaYRruqpnFamQFew==}
 
-  '@utrecht/backdrop-css@1.4.0':
-    resolution: {integrity: sha512-94btKKs3V4aihN/KGFr0DY+UwpA+55KSzAHT2PIRiLFxoxCqgNXeUyH2ev0abmypMZ6Du2BrbWxreWA12yIJRg==}
+  '@utrecht/backdrop-css@1.4.1':
+    resolution: {integrity: sha512-nUUSDod9nYkGlwjvVxHplOjdYnrtqewqXOrO9A7PHLyUm43thQ8XBorhAG0IDtFxHT46JfofMxuCIMZr7PZHFQ==}
 
-  '@utrecht/badge-counter-css@1.4.0':
-    resolution: {integrity: sha512-cq90//8FLRw++OJxDZat0yu2thkgX8MdGCgKO2h1YOM/IE9Q4w+zVaDE+ImvXVMSyI5dJyUYIZBIVGFsAsjbpg==}
+  '@utrecht/badge-counter-css@1.4.1':
+    resolution: {integrity: sha512-pEyVTH9CrFxNaNfIuFxgGBl5Q3ZecU4jsYJL+2JBXTzJbgy9dI47CvDMQzEkASkBCR4qEPeMB6f5b4XQRBOipQ==}
 
-  '@utrecht/badge-list-css@2.2.0':
-    resolution: {integrity: sha512-k/9icmEgPQUhZrzupIKtTl9tAUZkFZnaNpEHZp8kYJp9qAc9FY3ZGNBOr4XasqbdL/EZ4bg9oZrIb53jnzcRuQ==}
+  '@utrecht/badge-list-css@2.2.1':
+    resolution: {integrity: sha512-C1HCRQ12CTuuFvmbcUEYsI8SuXe1X7y/oC9OyHznfyIJYkINm9NZ/30WIu99fgd/GkwjFyQoy24J990zteM3PQ==}
 
-  '@utrecht/badge-status-css@1.4.0':
-    resolution: {integrity: sha512-81g/nRq7OdIZY9P/VsQ3fZqsGkGNLKOJxWiszGSUw5x6N5AnaYbxqXziaIJNTQTHbBHBh47yc/1zcSJCkXoRDA==}
+  '@utrecht/badge-status-css@1.4.1':
+    resolution: {integrity: sha512-lXb/pi0tlrvz8dyYMyH2Q8FFKVnPd8+K5lQJCEY3oiG23PL/Cr+6YJl0oZx93e01Cc0Y2q6PriaLRPIJxh4T7Q==}
 
-  '@utrecht/blockquote-css@1.6.0':
-    resolution: {integrity: sha512-0VUJ9SwwIBVcBnxdcPl9cIkOXHCZEbG0GfKcrrzUXrMTH3rtWSyyMR3MyRfPnYFkiguRNM7ohJToV+db99ROUg==}
-
-  '@utrecht/body-css@1.2.0':
-    resolution: {integrity: sha512-hzUaFBjGSSpNbrI4gBspRjHvQkXLuMUo8MURsvEOoEgZG/ZDgUx4POvhBcXEyWKD25v5N2yA5UiGbNQbsnQTtg==}
+  '@utrecht/blockquote-css@1.6.1':
+    resolution: {integrity: sha512-rebGL4ykw9ck+WuRpQd8vhbVN3QTJhsiico3C3JWbYfG/vvafCDkTI7A6AkuNZvg95V3lMJqn2mkA7fj8s0YWw==}
 
   '@utrecht/body-css@1.2.1':
     resolution: {integrity: sha512-YKB/y3Z+OjiDp39HTInrEme8ZOV+fffeHLybWTqCQjiP4JdPyiwUo82p7TYoyGe/isSGOSJQqVByhniadZI8mg==}
@@ -5686,79 +5683,89 @@ packages:
       react: '18'
       react-dom: '18'
 
-  '@utrecht/breadcrumb-nav-css@1.4.0':
-    resolution: {integrity: sha512-mBe/Xczr2ekfT9sxl9svOtZJWrW0klbnWBDyhf4it4zOk5BKeeKxUYEjbOQghOQ5jqVRPdnRbIVZoKX0Vrq3sQ==}
+  '@utrecht/breadcrumb-nav-css@1.4.1':
+    resolution: {integrity: sha512-YkBW5JIqvCm8aYwrw3EkaxBwjv3yEZRY5ms7CuZ3ul7RPpW5YhYRN4r5BUXxywnmRmHsoPvoS+0tdug8KS2GjA==}
 
-  '@utrecht/button-css@2.3.0':
-    resolution: {integrity: sha512-3RYtaqzG3ZvOH5RcGXbKLv3HizTacYXd4BPolzDKYMbw/1J/x6/A6wRovzsUoOIhoIIZp0S25/OpxdPnwt3QQw==}
+  '@utrecht/button-css@2.3.1':
+    resolution: {integrity: sha512-gjCVKTzsV/2TOTrYANHFP1f9RqXc/6lY+gC37q9KaEJZ55+37mVKeNubCO1ntFRJeGY+4oCT5ti2rtX4jqDjqg==}
 
-  '@utrecht/button-group-css@1.4.0':
-    resolution: {integrity: sha512-NV12LA6wh0IaBuqjVVD+dZUzl4Sk0aKKiO3qL0BT7XQJvygDRjJq3M5d2pI9BDMMOb9jgT6VuIARST0Qk6JuxQ==}
+  '@utrecht/button-group-css@1.4.1':
+    resolution: {integrity: sha512-RrYY5834h9eMM4y63ghOzfkMb/mb7d62zHUsreC5vZgN+B6Kmx2ZIeS1tN5JV7cSrBQN34sBIrkMVLCUsctHvg==}
 
-  '@utrecht/button-group-react@1.0.0':
-    resolution: {integrity: sha512-0tjYrQvNrY92rmJDAgXDEpdhfYG7bFgfEfJNygofufHE/W0KvEC7Ndg384/IxihQbCuxinXBBAfI04VMxQGkoA==}
+  '@utrecht/button-group-react@1.0.1':
+    resolution: {integrity: sha512-gZfKsHwwZxhKytrEKexDs1OOQ6O2c+2jgWmhp5fKb0DhqHluDnQ4xKKKF/BwlmjOyjesKwBwrvVJc+jsd/dIQA==}
     peerDependencies:
       '@babel/runtime': '*'
       react: '18'
       react-dom: '18'
 
-  '@utrecht/button-link-css@1.3.0':
-    resolution: {integrity: sha512-zA86MZD4rEF2X1S9jYU4NuliEZ2zVvhkwTjYV5AT78+uQdC8qy+VjSvzc2je6bdSpq4OeB1lpytl/M57KDBhOg==}
+  '@utrecht/button-link-css@1.3.1':
+    resolution: {integrity: sha512-jatHsTpTO25Jy3BWPNlcgiyZ9S0nRdu9CGz7E+qucgcmzAI99BN+vDGzrhRj+HS/UcgTP3TgTggjzcBx8q+Q2A==}
 
-  '@utrecht/button-react@2.0.6':
-    resolution: {integrity: sha512-d2sTzyUFK7Iua+8Q0G2sk9Whq0H/TdYhC7QBk1epXSuSJ9sbPZugt4Fp+h1TqnQewXa2KlKQjNU4kcKrdfQkNA==}
+  '@utrecht/button-react@2.0.7':
+    resolution: {integrity: sha512-mJ6rO4+86FitY3y5XO/ov+1YQkruIQYWuEVNgO+EShG70vm8pT8cuU7ReauKJq0JUgxKeaNYWdyBWha9Sz64/Q==}
     peerDependencies:
       '@babel/runtime': '*'
       react: '18'
       react-dom: '18'
 
-  '@utrecht/calendar-css@1.4.0':
-    resolution: {integrity: sha512-2ovq4ppuLPc3BIq7LPB8K+QpRORAQuBbwR8hyqx6VcdSg2v3EvLsMAEzBxHy/LHVfeY8K5/3SBZ29UjPuf7Ggw==}
+  '@utrecht/calendar-css@1.4.1':
+    resolution: {integrity: sha512-6syL8tX3TbJxWJGOR2xeNrssIHjmoDuif6hz4V4JzV666pxd4akWqTnJ3XSgxt8WXAwglMeJnB/ynSQDGF4wog==}
 
-  '@utrecht/calendar-react@1.0.10':
-    resolution: {integrity: sha512-pXN9Q452kY/gonZhIYYBBVQex/PX/DwypqPdtZNagQK92+DvFFqIgkVjYvIdEMopz8JL45i4r2DLXUf9ZHsJTQ==}
+  '@utrecht/calendar-react@1.0.11':
+    resolution: {integrity: sha512-SeiiPEznxzBXhYrjMYg1oXJ+sUt/1JdQ7qVw5EanyChlZ/qMkb+7FVWxIWmEZneLHtB//RA3s68XfzsSE0/puw==}
     peerDependencies:
       '@babel/runtime': '*'
       react: '18'
       react-dom: '18'
 
-  '@utrecht/checkbox-css@1.6.0':
-    resolution: {integrity: sha512-CplvwjHpjSEju05ZyvXilUWviLM9YFIpJQggSibW9U+E/duf64eEIrckGXmppVNFtoBu7IklKwcPbkQC3z69GA==}
+  '@utrecht/card-css@0.1.0':
+    resolution: {integrity: sha512-0hVZEzoLccDdTiFipWOT6rOwGuuEkCf8BqcdY8OPl4jPcShbAVfPpqIlsu5xgn6q1fPmrpQ75pFzYarEpccYdw==}
 
-  '@utrecht/checkbox-react@1.0.7':
-    resolution: {integrity: sha512-7DweteYDCrISULSd3wzYxkl7ZjV+zGOhjm18EbQ7XCyhcmcSElMiN44h/Fy7hwkKrOpR0GILv1ZNw2kysmw2zQ==}
+  '@utrecht/card-react@0.0.1':
+    resolution: {integrity: sha512-gixswYEwgW0BTk4RecoAV8H0f9w938DphNSCu4e3Z5+ePNt4ZoaG2W3hRuJXTImP+NPXiLkAKRgzbq+qXjxU7Q==}
     peerDependencies:
       '@babel/runtime': '*'
       react: '18'
       react-dom: '18'
 
-  '@utrecht/code-block-css@1.5.0':
-    resolution: {integrity: sha512-DjPgPQeqgfaf4aPyXvqwkkwGchSRSH8x/TfYEMIJaul7QxTylSM6/aORFCt706NNnDoQxPGjkAuHAmsMpbjGMQ==}
+  '@utrecht/checkbox-css@1.6.1':
+    resolution: {integrity: sha512-P/S3XvYVW+3sgOAub68eZC/Fn8HlJmG9wl5Owky/NyDnRihb811EicdyzEzc8ldpwuxD7n/YNmJLMyj5pRL5NA==}
 
-  '@utrecht/code-css@1.5.0':
-    resolution: {integrity: sha512-n2cLpzhufMTSZlKRGZDzhUsLDBcbLOQpZV/NyIPfkJA1jCfeSr+mI6BGVB/sGKH5k1NVEt+sB4jC+CRTqbj6jQ==}
+  '@utrecht/checkbox-react@1.0.8':
+    resolution: {integrity: sha512-Kv1qf3nEOZA+Y0Z5+pKYpDMOBfpL2eXqeAeedj0UTYXX6Tkvq3lUK8eB4CLuSNgBV+ejSUj3CuZoEiOENK4Fdg==}
+    peerDependencies:
+      '@babel/runtime': '*'
+      react: '18'
+      react-dom: '18'
 
-  '@utrecht/color-sample-css@1.4.0':
-    resolution: {integrity: sha512-AMVUEyg+7CkEh8xuI/hHt0QJ9p27wUi3BQOIsEvrl5Ah3Pfphomarg4uP99iS+goPjTsM0H+3hiJ6VxG0K6KaQ==}
+  '@utrecht/code-block-css@1.5.1':
+    resolution: {integrity: sha512-kE42aOvgcqrVqE6Mbh+qhAwKAMSMDaHrLcgjfwPKNc1wGlDkIgilPnxg4kQtNibBu6Anf6HGLj9vq6cQMCsTOQ==}
 
-  '@utrecht/column-layout-css@1.5.0':
-    resolution: {integrity: sha512-XnhA/CscHCwy5i35dOORgagmi0Ajhu/56Zr6ghRP42D8r2pcTL5YCYRAJ3qXozeQ+2QbDqzoGsVkYtmcuaJAFg==}
+  '@utrecht/code-css@1.5.1':
+    resolution: {integrity: sha512-QN9vSjNuVrGWTHDTLMrmctlFifINemRGI6GR4Bz9yoxu8L2VahlH2FkKV00I6xpR0oWa5Ol2bttII5VbA+vXRg==}
 
-  '@utrecht/combobox-css@1.4.0':
-    resolution: {integrity: sha512-cY+gBxxL6DOlImsTSz0BPeoB9yhRCGLnK6TblArzlhB48IysfWoX+SlJQp/EfY7EJpJSqH041ExLcxhUvYVDEQ==}
+  '@utrecht/color-sample-css@1.4.1':
+    resolution: {integrity: sha512-iHLcajGTvg+A+J7uhEVcO8y0mJhdhuKrHFaTDgvCy7zvyhknqKiI5Pil09TEQqtDesX8cL0zt3iXuPQ8RVuK+Q==}
 
-  '@utrecht/combobox-react@0.0.7':
-    resolution: {integrity: sha512-CWvCqWBghSTsLQt33K1UJYcaFfeIAz9u2y409FKm0HRgSJvwiNj8qLqugJZo7w8hhFfNJQNAzpTbgwGnLGDzcw==}
+  '@utrecht/column-layout-css@1.5.1':
+    resolution: {integrity: sha512-t1qT2fxdqkVF0/fra32jt0XDe2D1sVbDB9HOFSYcedQ13w20IYaaeogHiM57nZ5QbjHhbFFM5SaSWBw35O3ICg==}
+
+  '@utrecht/combobox-css@1.4.1':
+    resolution: {integrity: sha512-U3s8srLcTPjkn6pbzOudVsvUBwun4vLdhjQ2jyHGjsA/GDAU2Z2geGuLsYSFSJtsThMQ5QqfDtWj9tyYRKMByw==}
+
+  '@utrecht/combobox-react@0.0.8':
+    resolution: {integrity: sha512-JOKu+G2iAW7yCWOA9u19OlM1CL7jkUQRvl3lLuQWdOmZSU0WXC3KJcxi6Q1LCatZa8sSvss4wjFpCDMYTEm8/A==}
     peerDependencies:
       '@babel/runtime': ^7.23.6
       react: '18'
       react-dom: '18'
 
-  '@utrecht/component-library-css@7.1.5':
-    resolution: {integrity: sha512-6xwLslxJm2KJdf7HYyaa76VORTSMa8Ey2btZyRD0NtfJ/jfKBmVknpzug8A9wN87a+FvvcLtrbxXuz119UMnZw==}
+  '@utrecht/component-library-css@7.2.1':
+    resolution: {integrity: sha512-HI4Xx7+5nkwr+KRquBkEoXYYXnQldnomlPemA+C936/nxeb3LJ635Txnsg5Crx104+bDohw1VlL0aewauDiyow==}
 
-  '@utrecht/component-library-react@9.0.6':
-    resolution: {integrity: sha512-OmIASkH4qdyXfznaw1h0+l/Kn3Cjo0nH6FtxVP3jVip5smmSL5uaDKGvF65IsFZiOrKGWphDJWwpjKIzzTR1ig==}
+  '@utrecht/component-library-react@10.1.0':
+    resolution: {integrity: sha512-UuNKI2n1kOP1w4P/g5Dv+Lilsguucp2EDQHZWRFApWed7gQ1+XkH1u0YOnj1128rYdBzoxltLCcM71PgSLF82A==}
     peerDependencies:
       '@babel/runtime': ^7.23.6
       date-fns: ^2.30.0
@@ -5777,153 +5784,156 @@ packages:
   '@utrecht/components@7.4.0':
     resolution: {integrity: sha512-LWFJjJ7TF0eaoWq5TGrg7rNYnG+G5yIEJhuiwFlbICwSx2n+gZVbAE1dAW8YG2mGqveXZk38hBC2FWNE1tj1BQ==}
 
-  '@utrecht/currency-data-css@1.3.0':
-    resolution: {integrity: sha512-9PrVvMLIy1YBd+IK8XsnJHCshKvGHUQVbX53hnkVvR76vaIrSMMUqmzu/GK6SXVlA9hb/ZjKkKPMBPfsJ3YLvA==}
+  '@utrecht/currency-data-css@1.3.1':
+    resolution: {integrity: sha512-QXXcRjRxnAab/jXqOWciokv0bCaVxxAOlF6hQC3OW76w4aaVVSXWRE3mBw+7g3AQ7nLGsfloTGwTshenF0g6+w==}
 
-  '@utrecht/custom-checkbox-css@1.3.1':
-    resolution: {integrity: sha512-iChJIVwvWIgc4j3cP+0fcGHnOmN4cIevg4X27TxEADsVyJvTgjYfsudjAt4OlzYD/Vx6nvnY+ElDQhmge0jc/g==}
+  '@utrecht/custom-checkbox-css@1.3.2':
+    resolution: {integrity: sha512-DvrmyGnC7y0xTdCqGu4dpP1bdraPNvWYC8uzS8CAzH/w8mBVti4rctP5mTXa7i5nFQN3BWLu8WF8FRpnRTMdJQ==}
 
-  '@utrecht/data-badge-css@1.0.0':
-    resolution: {integrity: sha512-f+u4fYqOKEtFJrtiRcByDLnSTmlgMICjLDRgMMiRFZls9iq7jLK/5as8nOv/1dYjSdSWjN5AxeIvh6KmzWmWJA==}
+  '@utrecht/data-badge-css@1.0.1':
+    resolution: {integrity: sha512-GGr4d7duJCsiiZVh3S15AoMnCM+7pO8pNOgsfeyItuD0Xv5Uxymd4TJaxahhgLrjt3HlusIJPhEo0NPUQLrHJw==}
 
-  '@utrecht/data-badge-react@1.0.3':
-    resolution: {integrity: sha512-abKh1+ep6/uy/eSS91miLKvADgq+fROJK8keyM9SWz1Rw/txzlUJDOCPfKblHu5wJqWhLtmuZGOLeu3E/vdK9w==}
+  '@utrecht/data-badge-react@1.0.4':
+    resolution: {integrity: sha512-AKhXZGt345af8KBQyDmtJN/8C676NiyM64fYGJlV05L9Y/VyOpQi3ozPh+AUs1TA4K2jjI0jQWXi167KqgCb9w==}
     peerDependencies:
       '@babel/runtime': '*'
       react: '18'
       react-dom: '18'
 
-  '@utrecht/data-list-css@1.4.0':
-    resolution: {integrity: sha512-MdXOpWY1RJAZiyffGiZ9WtAJEUX76BcVHuen090rHWXHmqGZZ5coECFewcJmpGldV4Knex1Wc6EUUWa6RVJgeA==}
+  '@utrecht/data-list-css@1.4.1':
+    resolution: {integrity: sha512-MK+is1wSfaiT1mW8GKUottDQUbDymV0wJotlPDnaV97uV45xF2lpXyBWzmDLynESCQtQDHgGTVBPZvHzMVlF9g==}
 
-  '@utrecht/data-placeholder-css@1.4.0':
-    resolution: {integrity: sha512-gsyIHd7BlsbTc0iKIipDTYyZys89T7yDjgimbQxLAUhLBk/C/CAUTuAS4+bjQbXba6GfuGOr9TnvammAID+SXA==}
+  '@utrecht/data-placeholder-css@1.4.1':
+    resolution: {integrity: sha512-QaeWM63VGXfk5oT4idafkRmh1WwMfixgH+hfd89yW2dgjYnLjdJuJYpqsxBHVaBIsHzmhyC0FCNfGxMlz/qbkQ==}
 
-  '@utrecht/digid-button-css@1.4.0':
-    resolution: {integrity: sha512-1CEcZogvoKJHs5FKYav215/RdA3grBPWa4REK1JpXRoF91LkMD6ugESXkKq9jkX55jjYyo5/OabI0+zXsE0Sng==}
+  '@utrecht/digid-button-css@1.4.1':
+    resolution: {integrity: sha512-j/eU6dHgxehFjFAr5/PMqnE2j5ePnk0TcnsZvICK4dGbolbOBZf9APV50UCG/U1VL+FxOlrgUgwrVWxmFYxDlw==}
 
-  '@utrecht/document-css@1.5.0':
-    resolution: {integrity: sha512-BULQJRt7KUjsOuh6uol89AN3LjghH4U1m7C4OWTcqyGIXCltCPRKjzhuiUc/qe6twIPNhl72BDZaFV3I8Bbwng==}
+  '@utrecht/document-css@1.5.1':
+    resolution: {integrity: sha512-ZXE4qzk0/MCxphcoqjgNooOcMxobR0JzqvpuZllNvtYgMcL1NMLCZ0KIj1dpQsUruLjO+bqGNYsF52McqUBi5g==}
 
-  '@utrecht/drawer-css@1.4.0':
-    resolution: {integrity: sha512-QwrtXGZosbkg1e6XiAwmz0bTP/dOIJtDasZx3qu1M2p+NAQKUH+J/p1ea0bwYhiqpF1Pds8CLa0MUmGFycsTig==}
+  '@utrecht/drawer-css@1.4.1':
+    resolution: {integrity: sha512-xVP3QNOOpapJXQVfdnrb+igZqyEDdNK4Wf8hIHNrMHfGqwxelwW9caVl58HV4pSa4KTwtN7Vs7QUwfOq0Bm1NQ==}
 
-  '@utrecht/emphasis-css@1.5.0':
-    resolution: {integrity: sha512-qAyLYYy5t9unqCfkElUQqJ5tJiwiXB5WSMC8Y1EVBO2ZikEWSslQ03704F0B5keZhTPK73dEoUcgnS7tu852ug==}
+  '@utrecht/emphasis-css@1.5.1':
+    resolution: {integrity: sha512-qVwLe1+k23Xwzd26MTwErjh7piIUm3c2siZ7aaEpvC1wZ+PFgf4vs7xNWJXLz89plRJ4/5sivFLUfHY2uVP+Ow==}
 
-  '@utrecht/fieldset-react@1.0.6':
-    resolution: {integrity: sha512-bphEEs41EiCyi/EK9+2tWMAVnT57n/37j02rzBQLdr+UhM/lP4X0mpqbgsgMiSU25YIOBNrHiwBvekkiBM0p1Q==}
+  '@utrecht/fieldset-react@1.0.7':
+    resolution: {integrity: sha512-OilAF6SLn0fC5YbGbFfl6Ea6zfPD2yrE6L6SvtLjT+Gdbxx/e/XOk78+LmcQvY+cT2GlHxLzxM/YchsNBhOTOA==}
     peerDependencies:
       '@babel/runtime': '*'
       react: '18'
       react-dom: '18'
 
-  '@utrecht/figure-css@1.5.0':
-    resolution: {integrity: sha512-0h4tHjvO0HjXCST9iaz/rdYc+OC2rUGzWA20RXmTVGszEvnzU7ZA6cph8JhkY7OiJAnzLvvX19LsUwa0AzARBQ==}
+  '@utrecht/figure-css@1.5.1':
+    resolution: {integrity: sha512-KzkIIyGo3wAYXFkDeBV+S2m6InKqPLUpVy8EjBPRTB8WexiLfDKpYf1gAVhgbL+236fB30yWLkzukGO/AAUFBw==}
 
-  '@utrecht/focus-ring-css@2.3.0':
-    resolution: {integrity: sha512-HYsULqosoFp9zMypvGuEaGpsl01cW6qKGIYGQa9FZCcCtwXcS0dqFEcjeZJ1yue0RJsk0QuGVBrQOXjsNPNkBg==}
+  '@utrecht/focus-ring-css@2.3.1':
+    resolution: {integrity: sha512-mmZeNnp2VeYVrnG0uhgkLcX2nVuMW0+oZjJ7lCI1FFODpj3ORmtTi7N5UNjhM3Pyppg5LdDwqMM6jF9clPg5Yg==}
 
-  '@utrecht/form-css@1.5.0':
-    resolution: {integrity: sha512-qPooKuwzP61iPEhuL9lDks8uc55AI6ntveLrxdz334ttQkTWBjnHrOfs6T+5kRRZw+FsG6OXuUA+wKPk5YP5kw==}
+  '@utrecht/form-css@1.5.1':
+    resolution: {integrity: sha512-jRec11YkKtPmbLpW7bjkqHTb9XTCxB4VBxFMurCqpQJ+ISni0CKTBhGTCfZGLhWsNEVLpuIuL0UxhFNyE/ZS+w==}
 
-  '@utrecht/form-field-checkbox-react@1.0.9':
-    resolution: {integrity: sha512-WPFjgCopvGWNvd/ymDF+mWegTbtnHe3xLdETz8p2cdzhSt0JOZsqV92egEx92833RMOtmObQ4n0LGPUDDLO0Ag==}
+  '@utrecht/form-field-checkbox-react@1.0.10':
+    resolution: {integrity: sha512-vmg06zS5F9XgHfTciPNNLvmjfEc50wBy12tHwi6045Qmuy3g7L7CZ0fSPmNfxUf70RUPvgW7HkHRvhURFuC99Q==}
     peerDependencies:
       '@babel/runtime': '*'
       react: '18'
       react-dom: '18'
 
-  '@utrecht/form-field-css@1.5.0':
-    resolution: {integrity: sha512-PGqIYHYlqQKuADgIIQF4niS6XO1VeUv6OWrWDrLbFw0JkKtNwU9Y3ALtb5mSmgXAKOUHEtI7scwFqOxYgKztsw==}
+  '@utrecht/form-field-css@1.5.1':
+    resolution: {integrity: sha512-EILCtMcMk3LgTT5pUjna0vKA5S77Av1+fgqgfApEWU7y0wcC8UcYdD7Ujl3goJShhO02Fo7AYM3befJQgYBtuQ==}
 
-  '@utrecht/form-field-description-css@1.5.0':
-    resolution: {integrity: sha512-LGImfd2xFuNPvycIQzwtTg2UIAo9T06MI/KoTbchB56lPzXLmictzfn2rGDzZuaemWTwkxqKUzorLXqdonZ22Q==}
+  '@utrecht/form-field-description-css@1.5.1':
+    resolution: {integrity: sha512-oaLNNNl0rEKVmK3FvxAaYfAzrzhE3Ahsj2JweDCzkvihyN8lWRT0YZP4DQh04RNU5JuQ1VbNFxRp4SZh0jDPoQ==}
 
-  '@utrecht/form-field-description-react@1.0.6':
-    resolution: {integrity: sha512-8YkGuGMiZjbK4/8PE3oFAZZMdhlFbcupUuliyvr/Elzi5WxrKdNa680ZgR01e6DOZ7Jk0b+1Yy9wOnSIV+H79A==}
+  '@utrecht/form-field-description-react@1.0.7':
+    resolution: {integrity: sha512-laLmOKJXl0vUF3w1eJT9QENUgGz72mWPwdZOebGZfsH0pKKFLcvlXUcXQ+cMnCJyKcBjEdxeUN8DA75UqbKo5g==}
     peerDependencies:
       '@babel/runtime': '*'
       react: '18'
       react-dom: '18'
 
-  '@utrecht/form-field-error-message-css@1.5.0':
-    resolution: {integrity: sha512-VYkC40vinjvT764QBDh5kBdPVPfK4V02K99OnX9mGKPZvWaCL9UVH+DC8VPLIMWHKEHTaJLaqYGi2EwLybRcnA==}
+  '@utrecht/form-field-error-message-css@1.5.1':
+    resolution: {integrity: sha512-YuAaTsvxC4fWzIflFmnE1wvrDxXnDvtPbomifzy7fMUjXAHSE+I8XRfnMoibGZjRzz6NyBtitrwerai2nUTBww==}
 
-  '@utrecht/form-field-error-message-react@1.0.6':
-    resolution: {integrity: sha512-LF0hc1mq3mCxTLznqfxOWxeiyXLoiitsNDnNhR4k8KSwqllJcIVCUHjqExT0eUEo1ZY1LH/qHQpimm/TiFtAxw==}
+  '@utrecht/form-field-error-message-react@1.0.7':
+    resolution: {integrity: sha512-SNgHTANBkoYv72VpdGOU9Q2NJHSYNAbqWxaFjKM9sXT4EVTemKwL+vSEuc9YmEECwK10saMRTz8eq59ytzHkbQ==}
     peerDependencies:
       '@babel/runtime': '*'
       react: '18'
       react-dom: '18'
 
-  '@utrecht/form-field-react@1.0.6':
-    resolution: {integrity: sha512-ArGvqcSmxqDNUBz6grV62kHm0uSLMFoyQwjWLS+7U9mFp7/SgKLIa68s1GxWs0CyLUxYPwlQOCKkN8Ff/ZZdeQ==}
+  '@utrecht/form-field-react@1.0.7':
+    resolution: {integrity: sha512-6fBKG5stkxNj2UnyvpK2aSpLYNGeEX5qmqG0Ma8yneVgzGyEOtQqkjGr8bmM0QlIgdGvBwn2E1ePZD99Vyaa4Q==}
     peerDependencies:
       '@babel/runtime': '*'
       react: '18'
       react-dom: '18'
 
-  '@utrecht/form-fieldset-css@1.5.0':
-    resolution: {integrity: sha512-11ctmOXaXeIYjpIUP84DkuP681mNj5hTqwkFvepIHBpfxlV97Hx+GYvzll1VUjb5pMasBCpc/cwWGxXx8pPBrg==}
+  '@utrecht/form-fieldset-css@1.5.1':
+    resolution: {integrity: sha512-ORVxcAXSbPLr0dLuj26XhKY+3/YSdUSjj5r7V8cTYXbh32KJwaoAOrAREFo0Jm1i8vJpwxAwsptb7o9Lmhpw8Q==}
 
-  '@utrecht/form-label-css@1.6.0':
-    resolution: {integrity: sha512-pLTS8nBXVS4QsxJndiZoE2hc+eN9DLnWEs+6YSY4LHFO55rpDWlc1Xi23oCYNSTtWH7YGStYnezp8VKPbk5Z5w==}
+  '@utrecht/form-label-css@1.6.1':
+    resolution: {integrity: sha512-h9d0FpM/VRbeVnr9zd/9Mbr+paKHa2OaJn0eP2ncCBHlLveb3Mww3rl+u6t0vw0lB8mrUAtjDWCLAjKNc8d0Gg==}
 
-  '@utrecht/form-label-react@1.0.6':
-    resolution: {integrity: sha512-15QLAS8ttsIpwiZiffGjQFKLJ/WizboyxRh9Vj6DqifubA2CGpcH//5OD1F7MSJT6nQuYbxOfRirjgs+Tj3Fmg==}
+  '@utrecht/form-label-react@1.0.7':
+    resolution: {integrity: sha512-rzc5tlLvtRcBFUjZkSqOAdn6C3mHdv3+IITfo/ZXL+HDN6XGzHR+/Rk6ACKfo9hDXad2jJV8bIClWEp9U/yhpg==}
     peerDependencies:
       '@babel/runtime': '*'
       react: '18'
       react-dom: '18'
 
-  '@utrecht/form-toggle-css@1.5.0':
-    resolution: {integrity: sha512-shOVvo0Oek5FjF9PuZAQHnjldJctzhXbwFcr3Z/447v2gvjC86uzLr7N+11QQsg4PLnTmGPta+dMTspP7Nu5ww==}
+  '@utrecht/form-toggle-css@1.5.1':
+    resolution: {integrity: sha512-WV8sXe/Jt4Ol/0ynjbFkqdMbDQQBY7JBmEHPQJJkoRmfS9SU9EgPbGcZjH2e8++lumXQiKxc1WddWcnJAT77Eg==}
 
-  '@utrecht/heading-1-css@1.5.0':
-    resolution: {integrity: sha512-gDdpZvtTQzY2h4iFOFxOM5Te94/R/uAHTqZbt7Vk34nKhxSe379sKAP5RbScNeWVtR1WfOnLwHPhYfd8t4LLbg==}
+  '@utrecht/heading-1-css@1.5.1':
+    resolution: {integrity: sha512-ihsXPIhPKW9CXlgnPJQxeuF05wQhxPIDEqStGarn89EnBDon9KCMzoiUEA19UiX06XBs8rv3pAduw2qfFX9wnQ==}
 
-  '@utrecht/heading-2-css@1.5.0':
-    resolution: {integrity: sha512-CQNljKKmmyywLoZWoX5zUWqTGDJjdJTFwRdGjigU1PZ6MjjKHOpLHt42hBChV3codGxjkrAUoFh3KKNfK7LLqQ==}
+  '@utrecht/heading-2-css@1.5.1':
+    resolution: {integrity: sha512-Wf83HNvo61dFvSXC+4z6ey3NafsZ85SVmAf3YTQmUY9qY9aElHTTnv1ag9hgPKSFEAh2mE5Rl+Yb/UT8x5TXYg==}
 
-  '@utrecht/heading-3-css@1.5.0':
-    resolution: {integrity: sha512-opXNdnUpqUbBSoE49aMgck4uzVU2eO5H3NZnX9FdUmzSIMjmXjXTazyc+aedJWvfchZtcRyMJaiJkGoSoqm96Q==}
+  '@utrecht/heading-3-css@1.5.1':
+    resolution: {integrity: sha512-oxVgWdaTLTRp2y1Sxhcu2xwDqaF0SEhjzlsuTylG6TI4r/fbTpenCcAjuDceUEkCmlIUKERpKgdJVuajmbJpRg==}
 
-  '@utrecht/heading-4-css@1.5.0':
-    resolution: {integrity: sha512-m6PinCZK9Zhsx3LKWWCY7MIMCJl6IGFY0vyAwyNIhadnqg+FqxLKVbIZRjzjYyojdTxhuDYl16pxWzYUJQ8mKg==}
+  '@utrecht/heading-4-css@1.5.1':
+    resolution: {integrity: sha512-KJNOoZ8cFCz/glrsc9n5FM5vsiHtMQsOe1ekxGzHMmE38aTrdZ5L81bvKeWbzztvbpxXm5DzT+tS5DqvVYJ93g==}
 
-  '@utrecht/heading-5-css@1.5.0':
-    resolution: {integrity: sha512-AB6WtvpuAjx14d7hQxhrzUT+gE2Ftwz5kxZr1wGTNyHYr9a8D7b1+WI3GJn8EMnGuTR6+gMMNrZI/llhwXUA7w==}
+  '@utrecht/heading-5-css@1.5.1':
+    resolution: {integrity: sha512-eN+BKXyoa2UxTKORxOAoeyMZQ1c4thi5+qlaxuPkQg5SDHuq0IZsTXaDWPRaoa05J+85ez0SnoEC0LAJ1f/Bcw==}
 
-  '@utrecht/heading-6-css@1.5.0':
-    resolution: {integrity: sha512-TtLDie62GuS3KzwNurt/zd9hsS/N5/ubwDWqpQa5t7io6YR1esujelm49m8d+Jfjhnva3Hw9TPbtDQrv6gTw9A==}
+  '@utrecht/heading-6-css@1.5.1':
+    resolution: {integrity: sha512-4r3Kd+Hej5ugLdiVCKlcN6xdXxzL8X/saW0pfK+3qPqGmhU3TV3r2axJqxLA9Q5NTDabZZuZeDZiqfwKcVsWIA==}
 
-  '@utrecht/heading-group-css@1.5.0':
-    resolution: {integrity: sha512-kna1H38A33RP+M25rATwnJW/Al2BIGXE2ENZiL1MOa9B9i6R/GLNwxxH8VH5iO3s7mQdoluUHqokuW79JKHY5w==}
+  '@utrecht/heading-group-css@1.5.1':
+    resolution: {integrity: sha512-INFePIMQevIK1GGlyfPe1bccrtEDg8hSfkIYt6Ts+l4ptb5yILFhPrYT+odW2Pq+F9h9HPJ0c545kZnik4VhWA==}
 
-  '@utrecht/html-content-css@1.4.0':
-    resolution: {integrity: sha512-nSZpNmHah3Xj0oI3IuZ43dwKesh8b4pi1MCdgUFg9WmbCQaCL1V7cWohZos5c4xJZjForRVj/Wpb8eA2TNEqsg==}
+  '@utrecht/html-content-css@1.4.1':
+    resolution: {integrity: sha512-PoahtxFSwDqKrMXcyp0yQeIZ+g7J+KVvYtw9POkiorIiRDC+NOWQtNBkP1Pb1vT30WtY+u1yMeEfzs1//dC9Lw==}
 
-  '@utrecht/iban-data-css@1.3.0':
-    resolution: {integrity: sha512-mey//OHtmp/UglR1ujozw+38+sTG0qXeBZCpQ11Ah9nEYsveGloVCY+q36TOE3CfgqxMsdPgVM70/aowfIfVMw==}
+  '@utrecht/iban-data-css@1.3.1':
+    resolution: {integrity: sha512-NbFZUG/ZSmwiJeiHtMVlkZaPxU+Dw/Uc03UZI1Y8NvCoEe7q+ozKhBqY5161pMaGyVCuLgF872DvZxh3bQOtMA==}
 
-  '@utrecht/icon-css@2.0.0':
-    resolution: {integrity: sha512-UVqsklyzB/Dj4Pl6pBJsGnEtZ38+0NzFFFSLmj08YfvOQGjzHhBkbcJgjZbxyn9qTPyip8OjrYkclYKhtl23Bw==}
+  '@utrecht/icon-css@2.0.1':
+    resolution: {integrity: sha512-zdoeqPlVO7bWq/XgrgMMykAwiHBgyFmLpx/LcvfF39EnRUyUq/ZnViV1vIPsiA4F3Nnwqvr6D+06IuSDYzvmZg==}
 
-  '@utrecht/img-css@1.3.0':
-    resolution: {integrity: sha512-7h96sc5Q66LwF9ZWV5aDaG2Mg3HqGpaeebkOQPWNMfQpPJ27A0S4pj65wvgqFNXVclc1TVmTNKiiWj4uSj0z7g==}
+  '@utrecht/img-css@1.3.1':
+    resolution: {integrity: sha512-d6l6Irm0Hi+S6mUT2CEEuJ9W1lNPZp6YSl3pFO3aZXl8gxVOFpI5eqqQO/61e0k/K7APJB/Hn7C35zRRZLkqgQ==}
 
-  '@utrecht/index-char-nav-css@1.4.0':
-    resolution: {integrity: sha512-0ZNg9jBWY1hEbdJd9N8Bt/LvXV/PUHKrmb9008lO5vOJ2yI6OajTSBG8OyhLAah+JhcUEjYWST1QoK768qR7WA==}
+  '@utrecht/index-char-nav-css@1.4.1':
+    resolution: {integrity: sha512-uHMlZweA8YO9JCkPfDMnxQuSXvLq/3orj0SMmH1kltJbUQcN9VsvG3moF6e20Oe57bMgTMXod+QnuvB4RArzBQ==}
 
-  '@utrecht/link-button-css@1.4.0':
-    resolution: {integrity: sha512-RIljT4vTWAS/g/b2lOQqpEy3ll+rqvUBEXVbaAW4U6FJzXyCdAqu8gQQZS3z2Ur9jsBECFYjvgviVF9PzjmH1A==}
+  '@utrecht/link-button-css@1.4.1':
+    resolution: {integrity: sha512-Mj8TTxUIc7ZQm6S2t/wHFhP1+43fWdr9MmLL1pHfZ+0le1Xn7EfMLMldVRLl5oDKbsXjxB5l+wfJoKeyv0cBfg==}
 
   '@utrecht/link-css@1.6.0':
     resolution: {integrity: sha512-fdLo+YYwHA0Y2r5kww0EhoJnLKI1WMPYW9SjJT0asHzYBVWo2YuGqhlp4YlG4uHJPC1KyF201znOx4Pa7YF4Uw==}
 
-  '@utrecht/link-list-css@2.3.0':
-    resolution: {integrity: sha512-rpPJ6MJhnMscO6B5YdufXg9ERteiDsWZ4b3PlLxyWXQkIeKS+/By+b7ER7VJhYSKP+J9TIjuRFxGF3LTNhO8WA==}
+  '@utrecht/link-css@1.6.1':
+    resolution: {integrity: sha512-99cJTMztRvcgDDCM/EGvjtzBQ6k7Fh8/sv6bHS8lQxoCHgm88m0fUfns1RJkrLEFhYVsbdPxqYTn7npZhsAUtA==}
+
+  '@utrecht/link-list-css@2.3.1':
+    resolution: {integrity: sha512-KUzAe2dUd1sdoSLXFyqv1DjsjyXi9gJyHONGCEcQAkxpHYA4O569XQQnH4v9KVhGgJNRKmtXgcDJswMW09t5Xg==}
 
   '@utrecht/link-react@1.0.6':
     resolution: {integrity: sha512-XXKNPAy4Y+IL+fGw+6B4DQc1J9qls8CO/DAjFwsfioWLnDhjypOiAiOh6xTVv7PTQGn7sL3KwtX9cS4K1GI2Cg==}
@@ -5932,70 +5942,80 @@ packages:
       react: '18'
       react-dom: '18'
 
-  '@utrecht/link-social-css@1.4.0':
-    resolution: {integrity: sha512-cT7TTkCoj2p7h+b7tnGu8JbpLgZYkftg/3KBWrq5EIQvjdrX0w2yuRODy8o+Ns7EydNEEeYsNTiKuAbrxRO9lQ==}
-
-  '@utrecht/list-social-css@1.4.0':
-    resolution: {integrity: sha512-hDWsZb3vPe4lzKmc8OpFGz0fPdM3f8SUdCos9pQHjwvhyj6mjBrCoVDqUaBIkxpf9vHkae8lt/FPX5duhQCVCg==}
-
-  '@utrecht/listbox-css@1.5.1':
-    resolution: {integrity: sha512-cjbyGoBXkZgxlRSZdspXZ1gjZS8qE0GKHKgL/+q30EdIxRatqNOYV8HxBgGEWGS/qBlnvDjh7znEPFtrDghPsA==}
-
-  '@utrecht/listbox-react@1.0.9':
-    resolution: {integrity: sha512-+r2tCpTu/mUMzt86mRnAvN6IwtKuxlu+YZeFBVGTH0OmI/MUVy0yFPfQ8EaGxI8rAVARkxNtGDSyqLMNLzWJJw==}
+  '@utrecht/link-react@1.0.7':
+    resolution: {integrity: sha512-U4mQ1AnrjN7LV2txBrghjgnS73eExdIsmuVUCvwqR/+9XvuG1u6fvQfanUVXVvvyX4TVbSqJHwZ8GeKW9TthSg==}
     peerDependencies:
       '@babel/runtime': '*'
       react: '18'
       react-dom: '18'
 
-  '@utrecht/logo-button-css@1.4.0':
-    resolution: {integrity: sha512-7fUlSHNqBoGzeBfeE0c3c/9daEMuNwRJJmHf6bntb3YmRY9bcw8mZGbi5jZQwcsN3OjpVFpj88ufjX+WHOEFsw==}
+  '@utrecht/link-social-css@1.4.1':
+    resolution: {integrity: sha512-j+I2mncqYN7ftHXm4+qC8w/JP3Nj/qJNpJ2KknCV5pAY7x4EU1IU3IlgeTiyfRsyN3S+QN8nYsNAwGtu/Re3/Q==}
 
-  '@utrecht/logo-css@1.4.0':
-    resolution: {integrity: sha512-ijnom/1MS3HslSnZHMTwZEWbGn95Zx/cDwV6omTfocUgHj4oOKXbS0LeCo/KlCk3kNFs538bO6rvMSzK9z7cvg==}
+  '@utrecht/list-social-css@1.4.1':
+    resolution: {integrity: sha512-Obovdz48uLQCm8/NqH2RK+FzIiWLUs3aXV4HKHU1F5DM32kL/j4ZiwjTiPXUGmnsMWlgfQw8ApRJb6nNWuf1EA==}
 
-  '@utrecht/logo-image-css@1.4.0':
-    resolution: {integrity: sha512-aycM+jLFGLlwHzfnIC8HuKls2ZbWTvsAaOedin3+hyrLBEz1Cvo7r/aSi4y+8u2T+gANXga6+5c70KnD5trCVA==}
+  '@utrecht/listbox-css@1.5.2':
+    resolution: {integrity: sha512-6zA5AEx0jJx3juZcM1wzw38hl0mychmrpdZd91K4zUWE8fFAAa30wg6xxFNNiC4LiatqgR+ahwch4NfUddHpNA==}
 
-  '@utrecht/map-control-button-css@2.2.0':
-    resolution: {integrity: sha512-ZMaB1RLCVC5PERwtQ/6l7SeNuCYqbN0edbtpvHtn2448iPDFz15NauQpQv5N6dym+Yrws1KggSvPVKBG+OGMvQ==}
-
-  '@utrecht/map-marker-css@1.4.0':
-    resolution: {integrity: sha512-0UC5Oe2h2FAuVVsYzwzS8tFWpcrWJeohTC2u7tNSx0Q2J7FmUUDz0i2IkfPOcg1DlGS/WeZKq0dgGJRGR8MOsQ==}
-
-  '@utrecht/mark-css@1.5.0':
-    resolution: {integrity: sha512-V5ACWV3KmQ/E3TLFTomE00lklVlY5EpNkRUI1vWPffRndD77HQxWat28tRGeSnxVLWDzMMMb94CcAohyrd0zmQ==}
-
-  '@utrecht/multiline-data-css@1.3.0':
-    resolution: {integrity: sha512-6HribYZFBLbON5gYDsoBKHR3zB7b8mmsfZVE5zMcE62P32nPmw1SHoDkVzTEe3Sxc1o0NAqNOLZUk0U0b13sIg==}
-
-  '@utrecht/nav-bar-css@1.4.0':
-    resolution: {integrity: sha512-q2gC9Ks7+fktmTyDrulcxhyFa9yKLPYIsDZZxR52PPKCp5wFiCKSicwKcIcNwibwn77FM37HXVsMkgy4IzzDTw==}
-
-  '@utrecht/nav-list-css@1.3.0':
-    resolution: {integrity: sha512-sLHPU39jjKTzO7pqh977VUC63vovDNHG7NsKzNZfWppvQfHCBzfCg5qi0hSdFxXOafDyVMx0+5eQGfbI+Zv6pQ==}
-
-  '@utrecht/number-badge-css@2.3.0':
-    resolution: {integrity: sha512-VVFXeNPf+j5u+nqXk4eR+PDOul8lZu3Zp+Bxsx6MRyiM74yqQgtXZjbhbk/onlhIkvcyXiPlvCqxuHOFBERpLQ==}
-
-  '@utrecht/number-data-css@1.4.0':
-    resolution: {integrity: sha512-ahIVb7fAMbLighpqx11tZ/xP5JWcw+PJRJRVv4wRn2xPSnMEbZLoDFyObSobBXfLUbLP+9VN06iQKClvrVt4FA==}
-
-  '@utrecht/open-forms-container-css@1.0.0':
-    resolution: {integrity: sha512-eG6wH6Toyyvku+s03pxqEXNPyoSdOEwyWpbWD9vdcuYK+MLe2i8ANWInVlKYgfluBKvuCv/akmZjelQUFpctjA==}
-
-  '@utrecht/open-forms-container-react@1.0.0':
-    resolution: {integrity: sha512-dqP8mPXce1r2SxfkhbgeWHyZpZJsNmCEOArNgnjOBQY2/J/IqJcmrrPx6WDWUpJM4nGZDJ+a2jUEVTiRkNJ2gg==}
+  '@utrecht/listbox-react@1.0.10':
+    resolution: {integrity: sha512-wFkhA2fpxCCFcjgv7wzjUmbdBL1kieK0wVGjEXM4vL6qWE8VVTI8U23yK6Lka1u6H0NNbYDlm6ZESj70Vk2m8w==}
     peerDependencies:
       '@babel/runtime': '*'
       react: '18'
       react-dom: '18'
 
-  '@utrecht/ordered-list-css@1.5.1':
-    resolution: {integrity: sha512-R8QIesxKw89lmhHbdrtYJmXsiTUQ4oyhg+ZqIh5OyrG19Njmp/FBRM5SRzJdTeeX24c+JQUM3phVZebKj0widg==}
+  '@utrecht/logo-button-css@1.4.1':
+    resolution: {integrity: sha512-KXR282BYz7zkTFIidR5qX8UhVWrcptJgN59/eYElPlnxreS7ry49/+vWqy0OVobD2TddTjENH9QZOn1JI6aYqQ==}
+
+  '@utrecht/logo-css@1.4.1':
+    resolution: {integrity: sha512-6ImqbLcRPhqVUP3toKG9rryoWWQTDKx/LmUgFQIe4OwPaJC/y7YM2pArdMtxiimJ/2hHODG2xfsHmkd+3qxBSQ==}
+
+  '@utrecht/logo-image-css@1.4.1':
+    resolution: {integrity: sha512-LIlxXGVZ8/9mWpPZw4Hmjdpe9Ax5KvcKBG0BJiPC1M4Cj8BQ6FPRdcc+iDllbT16OwBcCXqyDpUmlVto5RCpXg==}
+
+  '@utrecht/map-control-button-css@2.2.1':
+    resolution: {integrity: sha512-zZyLH123Pmhc86oc5BRwLhaoPQy9vCzdWyfn5n8LIFxDyR+y2s5tMxvFvieiVnYPimjlxuOecmM4IhwHttcSpw==}
+
+  '@utrecht/map-marker-css@1.4.1':
+    resolution: {integrity: sha512-vOTETT6R2buILbzZ7ViCnuIFqYtoXILE8mGtUwJmFsK0pRTM/KUS3+SfvqSajTAiDZ5kjTzJcWQJBQjyiOTi/Q==}
+
+  '@utrecht/mark-css@1.5.1':
+    resolution: {integrity: sha512-hPiiBuL1uM+U0PNlhVm6dZnO2afbyz5tRngxqak38q0vx/mAhomDCRinDA3fTSKSqoJPzRLHYkKg+eOTeeT1ow==}
+
+  '@utrecht/multiline-data-css@1.3.1':
+    resolution: {integrity: sha512-2AJ1Xaet5kqNmMQhZEz98F+gf06SmExcGgy4KllKhvuQbi4snCdv6CUKyQS1my/arT1ehWrgmfmQ9pSAeBhwqA==}
+
+  '@utrecht/nav-bar-css@1.4.1':
+    resolution: {integrity: sha512-wKpUeblwDlEzb0dEiH5YoLsysTsrqgcxbb+KmyZ+lcWlK9PNvKIIBhlA9TZUZV+eLsWWH7xr7mSRU1hUMyYryw==}
+
+  '@utrecht/nav-list-css@1.3.1':
+    resolution: {integrity: sha512-98fkAKiGBL5xH400oHFD6IoQZy3/fdQNFIDxP/HPKz94TJrAeD5smQz6/qWN9QNAj8tT3nuP+5DQSgK3uMqSNw==}
+
+  '@utrecht/number-badge-css@2.3.1':
+    resolution: {integrity: sha512-19YBkbO8CqHrkjZESyIE4lcbilawirkiU4aDiJ4w411geBibDqoHOrM1+uKAlIaCBEUJp9UnFMX8X34Il2xryQ==}
+
+  '@utrecht/number-data-css@1.4.1':
+    resolution: {integrity: sha512-Tgg3bZIYy8aUn3Q/TAfoIZTbbnSHZYPSzbVBFYduaDgV3e7hTeJpPmAl/DWZVh8PJ+ZuudQmcON0+mAuvuBtRA==}
+
+  '@utrecht/open-forms-container-css@1.0.1':
+    resolution: {integrity: sha512-HTISSpF5m7s6wyaLyvizVgoPwwylecO9RA+JgIk3Hb/WI9SR4r5tvmATmMLz7sarfd9lXN8yzFQu2qWIxX7FJA==}
+
+  '@utrecht/open-forms-container-react@1.0.1':
+    resolution: {integrity: sha512-vad5PDfGsNHqNWBpuTqXAssHN4VaWAOk7gd+fVFPwa3luIHIl4dkKEPi0m3UfUMDGyR4wi7Mf4T+q4twP8I2iA==}
+    peerDependencies:
+      '@babel/runtime': '*'
+      react: '18'
+      react-dom: '18'
+
+  '@utrecht/ordered-list-css@1.5.2':
+    resolution: {integrity: sha512-REpbulMzUc+E7zLSbPacYrYB9Y0Z2a2vcy5cl8RYgkMm8wzqe2LBj4d56HqKdCdNXjhheC2xZ1/VynBpUtgJyg==}
 
   '@utrecht/page-body-css@0.1.0':
     resolution: {integrity: sha512-vo4SH5/v73I18uvoBzVqHLODhBADdPhvveqyISz0kB4Nz2E4QCFoLZ0n+oqStYmUieVkHjCOnu3OSR2fYLLX/g==}
+
+  '@utrecht/page-body-css@0.1.1':
+    resolution: {integrity: sha512-uJFUi2IFjRCV/O4NmhRUBGk4cM3+p+D+eumkCwn6mLv+20/vQAhZqfb0Fj/TTx7R/kSY0Oa8izualDaPB/iZzQ==}
 
   '@utrecht/page-body-react@1.0.5':
     resolution: {integrity: sha512-Hp6V56n2qh01+FCt3KFFRSUgUQJZUnnSWsZBkxQDUgO0KCbmuuqtC4nCdmOud3eA6R23/F0YtcRDznK35X0IfQ==}
@@ -6004,20 +6024,23 @@ packages:
       react: '18'
       react-dom: '18'
 
-  '@utrecht/page-content-css@1.4.0':
-    resolution: {integrity: sha512-/1DewTJea97h9d+eqCTKZy6/fZVIQCRsBVlh338SQG4YGnfS4A5hZBBAadAJMAOiy5KWbAcP/tTYNkmiSGLDQw==}
+  '@utrecht/page-content-css@1.4.1':
+    resolution: {integrity: sha512-v6jPlYUV1kcMCwmQdvbCppbkeUSWm6DkgwB1pchB03niQDCUR1LS46CBCgAR1uNUE5TOb1SH7w4vmn5/pcgWFw==}
 
-  '@utrecht/page-css@1.4.0':
-    resolution: {integrity: sha512-lwhOwIpBVcJ5iwDtocVPV7V/5tOnd4bUSmBhb80K05lGF4APyyO+Vkc6lQHVy4ONLEK7fOgh2MvYCUtKA8e/xQ==}
+  '@utrecht/page-css@1.4.1':
+    resolution: {integrity: sha512-D8OmqtZb9uP+7wKCIUL7O8zLOXwhOXydinNQ5BFmM1E9zkRtao2X1Lq9Juo54R0DNP62CI6lI9DGcL+vSy/I0Q==}
 
-  '@utrecht/page-footer-css@2.1.0':
-    resolution: {integrity: sha512-wwYJEDGtwy3a2xxSHCLCiNXfsNc7xzp8d+G23uRKLoN2EHt+tE5TP0Qdm+bXFmltbDEsX+Q7bRnPN4wAkMP/fg==}
+  '@utrecht/page-footer-css@2.1.1':
+    resolution: {integrity: sha512-ib4BqRk5avAdtxAPgMJaljnp15wfCJRv7dQABVQvs8jcB6Y/BGVgNq1srpjWjFmkcdtIELtwPpnB2Y7jcUUqOQ==}
 
-  '@utrecht/page-header-css@1.5.0':
-    resolution: {integrity: sha512-QB2l/cWhYZTcs9HVJG+/kf6cOCclNkqRGmVQ3hpc4pG0DC7w/GIzFquuVi0U62hqA0sqJ8TjPW5CqHesxrxLsQ==}
+  '@utrecht/page-header-css@1.5.1':
+    resolution: {integrity: sha512-5hQw6VCXf0tq0LdKhI2BnmMzyTIMvxVS48yguK2trgfzigHAhPCSpmgEeWGiZF6GM9eCNbPThmfEPTgXvyVgkA==}
 
   '@utrecht/page-layout-css@1.1.0':
     resolution: {integrity: sha512-nGPZHDvbhKn7wsMYSRWKqZIFq3PDmrjqA/b/GbeKHBTUTjDlnVa8qRsOL6uMPNEd/FXNHhV70ezfxFbVcbkyqA==}
+
+  '@utrecht/page-layout-css@1.1.1':
+    resolution: {integrity: sha512-pFiRgDmB0F4s23JIJf0akynHVfBt7l4rv9t9gvpTeOxSdx3KTNZsxSNT5PyQwIf5mlEHWidp6yxn3fvQXlMKmw==}
 
   '@utrecht/page-layout-react@1.0.5':
     resolution: {integrity: sha512-8qDLNqZQOmpVJSgPJfGXH7NpVlKpi5IOw2hHlBtwWn/cZBTqcipxJgcILByUQ4sSXm/ZoVrQa+mdBewtvnNzkw==}
@@ -6026,20 +6049,23 @@ packages:
       react: '18'
       react-dom: '18'
 
-  '@utrecht/pagination-css@1.4.0':
-    resolution: {integrity: sha512-I0vnGRHAc1sYcu5ZbJWj55MCT6attM8Eoc8BDnB8qQgY94GIB24heEmDPTrzs7sISdjgjQKcBMc76CEQH6PFFQ==}
+  '@utrecht/pagination-css@1.4.1':
+    resolution: {integrity: sha512-MpJWfGVQH4n31ukASPQE0dUY2vwHf7Q5SSojBnxJVhxo5IZ1gkRH30VlTrZ89pAr0oBKmfjVJzFSZIj1O4inHA==}
 
-  '@utrecht/paragraph-css@2.3.0':
-    resolution: {integrity: sha512-Qo6iX7a0T1xVSxwtmtqdhv30kTNNTLz45OGrdkXMms4IiiXMMsYJ83K43aCY/d89GlH5lwKfyPb9CU64fzfCIQ==}
+  '@utrecht/paragraph-css@2.3.1':
+    resolution: {integrity: sha512-sbOs8y2UZOfNp7CI9S2catbBb/FSQ8PwpyH3WNZ5LDcuF0fZgKoqijunrrpS5FPviTMmkLLCJIwajyZRqEzicA==}
 
-  '@utrecht/pre-heading-css@1.4.0':
-    resolution: {integrity: sha512-Jy3KL19n6omYMggb+OEQV7ebetn//GFkZZCJJaeFVnCoDdHFIIYPDLLBLikBx10Q9eH3YovdJcKaD/HeIsH2Pg==}
+  '@utrecht/pre-heading-css@1.4.1':
+    resolution: {integrity: sha512-bCW5XmqhjhoVdYWPAN0HEaTlJEOyezt2kX1qgNSVlQZ191uzfrJYr8bOsxM3XrClJTXlMHLZ0DQfC0sHtQwK2Q==}
 
-  '@utrecht/preserve-data-css@1.3.0':
-    resolution: {integrity: sha512-Kg0NLsia0xbT+VxJx2BeEayKNUOq/n6WQOlrEVkt4d2ytdgXlrUIhq4w92pMjyUhykeHHCJWPSPVZUviEyF2Og==}
+  '@utrecht/preserve-data-css@1.3.1':
+    resolution: {integrity: sha512-O4TdW3df2AJGHunXB5AzEGDi8u8RsdmSbhyVMO5XeVIjiCVztajiyXnRqfuFX7+OA0EZ5E3NUSjPuXnSEJnkQA==}
 
   '@utrecht/radio-button-css@1.6.0':
     resolution: {integrity: sha512-dXAm51b5YdiglNexA+LS2Jezee9R4fKkoZPqVR2D/wiP78ZVni+7Jz/8NrcA0CX6SX43goOSGirBeDmDnYC3Tw==}
+
+  '@utrecht/radio-button-css@1.6.1':
+    resolution: {integrity: sha512-AQVGKD100iVjBan4mIx/QOBflgZUdZpNVRxrrCE8eXwgzXCSGlg++Veqx9Z+88vH38CEl+evQynVBdssIydVAA==}
 
   '@utrecht/radio-button-react@1.0.6':
     resolution: {integrity: sha512-PgMSuNKoJWNiQEu5wFIzfJuryhjlQSraU2+8bJt7EP3u7lL3af3nWv+XvqDMXRNpEz7DtUcMjgGurXhD+1kDRg==}
@@ -6048,11 +6074,21 @@ packages:
       react: '18'
       react-dom: '18'
 
-  '@utrecht/rich-text-css@1.3.0':
-    resolution: {integrity: sha512-ifYmwckw/h5R1uEEXN/BNyt/+KMVkGQrgZX0CY+P29o/AK0i3aeEqrPMumdyqUgRTEbLfxKlgGj8ShJzS653yg==}
+  '@utrecht/radio-button-react@1.0.7':
+    resolution: {integrity: sha512-bvb2s5MOmc+kCX2y/hS7zbVWORwg0+D1PVWzKz8604A5/FYkAYJfKm8xronK8mx5r2OCP9zd2PMnUjh3yb9s0g==}
+    peerDependencies:
+      '@babel/runtime': '*'
+      react: '18'
+      react-dom: '18'
+
+  '@utrecht/rich-text-css@1.3.1':
+    resolution: {integrity: sha512-3MZO8RNUXdGy4Wd61J8L3y7KW+AvmugzYfmG5lpbjJtwJ9TZRQnCQ26vSY2cUfoRXwscNYK5yqiQklc5syqAHA==}
 
   '@utrecht/root-css@1.2.0':
     resolution: {integrity: sha512-zdg+EozmNtZGDnM68O2lE+VpfvAfcG3//q6w1hNOI58+4khQp/q+9wxlgV4CS73HcfiF+xjQ32WgvJ60P/j/Jg==}
+
+  '@utrecht/root-css@1.2.1':
+    resolution: {integrity: sha512-zgHxu5aeT1XOIJ3yI0EGYqQF7ZsJWG8DyKtt2t12+qMGRW/kxuUQMX9nk9CbE3nnku1TXEEPa3Zt7dV2/p8MQw==}
 
   '@utrecht/root-react@1.0.5':
     resolution: {integrity: sha512-I9vZngiW7zSyZa/szAanxlig1YsJ9dMbWr237wmJNECCeuEBW24Tm6CPN78pYTd34r63vvCyMYZYY64oXFOJGw==}
@@ -6061,63 +6097,63 @@ packages:
       react: '18'
       react-dom: '18'
 
-  '@utrecht/search-bar-css@2.2.0':
-    resolution: {integrity: sha512-9povIG5VECn6aVxpc1ENH03WZr5dkHK+zUObc4l4NbpO7fdz54LYS0qQLoRVzruJb+YlmOsnftEA4sBvyFD0sQ==}
+  '@utrecht/search-bar-css@2.2.1':
+    resolution: {integrity: sha512-25ejBTRmghiBEkDkEhomXkbky1OPYrHeGe8Tu0NMSPJiW4PdmCdXb3hg/2OyyBBMHHglwHNWqC5f91IqfPjEbA==}
 
-  '@utrecht/select-css@1.8.0':
-    resolution: {integrity: sha512-JXJPoGvihUHQMmw8U/IWfcVXttMIb10LDBuOshw5b6RzGM3dy+M0ff28hLoJXMIPQeMFUCh2ydsl1OYbdwYtvQ==}
+  '@utrecht/select-css@1.8.1':
+    resolution: {integrity: sha512-jgniVh7+z64xvXOj92vF12RNyi4GFOQ+Zwce4EgUQIJA8if27iRFyipa6bgCAiBrsRxQLOaVljuvbLEU0Emz5g==}
 
-  '@utrecht/separator-css@1.5.0':
-    resolution: {integrity: sha512-c3ZM2/zmogAOq5mDHOLrmjVobHuep7gHWGeRB+THnQ+kiI84ZAcM9MirAJgqxyPNN37nw6CpILhAtVcxNwHT+A==}
+  '@utrecht/separator-css@1.5.1':
+    resolution: {integrity: sha512-uzamK3Ry8fv9qDZ10p8kHK65TkuLI8oZkwysLwk21apdP8Lihee0M2Fy3vPMAVg/hGVVYvB740x8mm3ezDL+4g==}
 
-  '@utrecht/skip-link-css@1.5.0':
-    resolution: {integrity: sha512-lhn/mOcRtTuPKVow3G6unuctDHnTDEGFIS2nyT76Ri3KDGOyv5QvTlEp/blOXPMhUPnQV1eH6y13TmkSCCKyIA==}
+  '@utrecht/skip-link-css@1.5.1':
+    resolution: {integrity: sha512-dMibzoTNSyNSwhup0GIRe86FJIGdWYY3ax684M0Fx+/qQNJubsziu9qGMTeLp+DVw+wLXZ7XZlhhdDxmnwlqYA==}
 
-  '@utrecht/spotlight-section-css@1.6.0':
-    resolution: {integrity: sha512-dUKcskHCIbzbJKjsd591ogKqfbQeoDVgOnNUZcT80hz3Fdj+84/axQF4ZccuxyhJ7oRNdJlr2wnx9BzvkQCfJg==}
+  '@utrecht/spotlight-section-css@1.6.1':
+    resolution: {integrity: sha512-sbaBDiPaozjqz7irQj+McIrGWNAGBFPHlKl3phApCb/ljoccdo//fDdPnlAgp1Hhwz2sSkj77ISdg0NKfwvimA==}
 
-  '@utrecht/subscript-css@1.3.0':
-    resolution: {integrity: sha512-uj3/t92myPTU7Kz9vvARmt4ScgrkXOvmA9uOAysM1TzaReh3sy7xArVxa/qWvWvu3I9MiUi6zyIFfOmj8BM7Zw==}
+  '@utrecht/subscript-css@1.3.1':
+    resolution: {integrity: sha512-dXID0YHJCudknXkItRmhEAsbtev+7ZM1ZuaWCY9Agr9VfkxMU1Yz6gXRvZAIL9s3gdFXFhakXlmcw41gEph3jQ==}
 
-  '@utrecht/superscript-css@1.3.0':
-    resolution: {integrity: sha512-quTVtxyQNjKsBgD3GwsvPzM5vP+QwG/nhfp5N/zc3zRSpfW6RNNCYIUnrH93TOCJy+6GKXamNAmHMySVG0t2VQ==}
+  '@utrecht/superscript-css@1.3.1':
+    resolution: {integrity: sha512-2eKYNGhcTGlGWyzaSwyqs58K58gwLG1rpSmA2USeH7vNHQNRTXrRSqhOXvnaG0HbGMy5XWhv761SpnkbR09TCQ==}
 
-  '@utrecht/surface-css@1.4.0':
-    resolution: {integrity: sha512-QCehlqXIuvlbCV5yMoq8wbXNn6/VADOmwcqR5XA1nyQyZ82RBMKZkmNkMbDaITlJSIna8386AR4xHpzIXtltqg==}
+  '@utrecht/surface-css@1.4.1':
+    resolution: {integrity: sha512-PH80aFdNFpODzruBBRKq52nGmMnwMiyJDRt+JkOMAR1II+iNI0relXTOm0x6MOmNnqejSYufkh81Xdfcocv2wA==}
 
-  '@utrecht/table-css@1.6.0':
-    resolution: {integrity: sha512-hpw9VykWQT1UquVgdV38Q+pAzcop4Q9WIehUUx+nEEKWRdlUa4JV/HQ3PfuZjrdI29krewhjm68O6bctmtFTiw==}
+  '@utrecht/table-css@1.6.1':
+    resolution: {integrity: sha512-IEEB3JX19/FxAOyZHA/88h1GROSYsr3YxDIXsP+ea3sVUSyEcoUP0jgiKjcRV198Ad3p3+T07p79HhIuS+AhLw==}
 
-  '@utrecht/table-of-contents-css@0.3.0':
-    resolution: {integrity: sha512-8o/5WlJnjgAj7a5shLvt4WPULWsL6ZLdwnyv28O1FMtOL/HSvjR/HPLUdPb02O3md7Y7CkrZl1LgcBvv5xaR0w==}
+  '@utrecht/table-of-contents-css@0.3.1':
+    resolution: {integrity: sha512-+H4WklPRgZAyLALEe8PXEvB+0oli26sz0fS/NF91H1nZwIti8+T7b7rDLJ6e9M6hF6IVF9lvjfiSZHByeQDJnQ==}
 
-  '@utrecht/textarea-css@2.3.1':
-    resolution: {integrity: sha512-AYsFmc/zpRgZCtv1HtJF98dlgU3SokDPwdNWtQTD6GzgzTneH/sx9gbRlOcLvXEXKuqdwOEU56sr785sKpF0SA==}
+  '@utrecht/textarea-css@2.3.2':
+    resolution: {integrity: sha512-//1PLWGMvTqS6exirU0OUO3l9odc7S2Wg1kg4I82v5oeoniUbn2gNgVfvDonPx4l9IywPNhIjlMM/9VfgU8T+Q==}
 
-  '@utrecht/textbox-css@1.7.0':
-    resolution: {integrity: sha512-s5KSz7KH0Wp3nEQnqUDBLmqFISF8Quy7EMIuapI6xMHf/AQE9O+1Y3/xC7Z1rQsMai4rOPRokT9zmm5dqo8hMA==}
+  '@utrecht/textbox-css@1.7.1':
+    resolution: {integrity: sha512-MBM/NfMgdMSsaVJvE1Yk48Z0aAby2Bz4Vyt9CSFV38UZQU3C/kPwuQde3oJePCBnVJPx+K1YM8WhGcHF+c0Y4g==}
 
-  '@utrecht/textbox-react@1.0.7':
-    resolution: {integrity: sha512-6xCmlb8liMxcgRPchh59hF5AeO0PImln4kWiuOlymY94hnVr8BiSjhTbSeqaEI1i6AAAnGjytxyLjaAOGBAX5w==}
+  '@utrecht/textbox-react@1.0.8':
+    resolution: {integrity: sha512-o/pTcqCUoqOgHPP2rt9tMY6j0F2D2663wQGV7ATD32m4xKqQaAYVYq6gQTWUYgWCIfsteHVGaWpA0LcoAyzZ+A==}
     peerDependencies:
       '@babel/runtime': ^7.23.6
       react: '18'
       react-dom: '18'
 
-  '@utrecht/top-task-link-css@1.4.0':
-    resolution: {integrity: sha512-JLE9TUqDQnwN+yw550xDDhuFx8F4AtslmeLP3O9r0eQbRYNeUzoLBvHNXwFi4tlt5ZaNnUV5qMrpD/kHxiZgqw==}
+  '@utrecht/top-task-link-css@1.4.1':
+    resolution: {integrity: sha512-3vQT0x7Eqm9P790qnT7ukt1btMsG+mRZ6Hb+HCTAXXTdKBgeRUHdtkrBXZBF7C8gD7XgoSiotcYQzRLNKluJFA==}
 
-  '@utrecht/top-task-nav-css@1.3.0':
-    resolution: {integrity: sha512-6dRgbRJ2mx2gyRY+jGgT+5qaEMABtFVx2blqPTxuELfsv4dDMru9infF5JOdYsQvP7M6d2QoYRxdR2OUj9dzOw==}
+  '@utrecht/top-task-nav-css@1.3.1':
+    resolution: {integrity: sha512-AIwQwLEA//Fsyb3sNJj2+lQSZxRq/PVb9S8k719lX7LX5tEH6PkZKgsE/QW34I2RMUOZ7MTvpkxbvHObxhYkjw==}
 
-  '@utrecht/unordered-list-css@1.5.0':
-    resolution: {integrity: sha512-Hxoa0X91mRhZFWs7w3dusDEwesg+nQPAbaR7EoQz7MycbVJiyNuieowmhOXk1VOD/jxBryda1A405FvkTDTVxA==}
+  '@utrecht/unordered-list-css@1.5.1':
+    resolution: {integrity: sha512-BvpymaFp0CKdcqApqdj4nKhn/99MJ2i+ilYvPS2cgyYJCEZk8eH4GXiHZBX7YzwzLhV95oURnG3DM6RsZ9Ixmg==}
 
-  '@utrecht/url-data-css@1.3.0':
-    resolution: {integrity: sha512-ByvAbbJvsWaU9nitser/f+JYAjYtk2Cv8P6CydqlQu6evd4c+odkZcn0UnalaNZO0A+hOLmEAMd+EK2mzgmMLg==}
+  '@utrecht/url-data-css@1.3.1':
+    resolution: {integrity: sha512-hns7O3znPXnGaURecDKcrHL9gJDVJI+pQpHNbN5rJmtnAQbHE8YTg8MD8jOeEUEq6w3FUHPHVq5Neo4PEZQ3oA==}
 
-  '@utrecht/vega-visualization-css@1.4.0':
-    resolution: {integrity: sha512-VH7ailjkKyNancQg0h7QUVOjXwZr/VizbN7kp3MMb19MpDjjnSoctA3qzM3/5w48NT9Dz9ZDhv6bFHlYK5nktA==}
+  '@utrecht/vega-visualization-css@1.4.1':
+    resolution: {integrity: sha512-A8hhTx9r3J7RexQ1ruhyXhBcA21DZHDO+fUP7Q2otKB216StukK09qlfM9ZaSmwmpFs7l/4vWFZw2cMbct+Lhg==}
 
   '@utrecht/web-component-library-react@3.0.6':
     resolution: {integrity: sha512-LaF0NR+TV8mMlFmBqAx2IRHC7CYU8zArHRX4x7jD0XukD6HralpqG8dbnNDCeELQRpLDeTrLutQdQGCtMd3Svg==}
@@ -6127,6 +6163,9 @@ packages:
 
   '@utrecht/web-component-library-stencil@3.4.0':
     resolution: {integrity: sha512-RZ3gotTGoOa+u0lfANwpEEVI68cryBnMVtd3lOjWWYqMW4f1NQu8GoNw4xl1Gf8VeZlcfJE5SSlfNC/38/ozWw==}
+
+  '@utrecht/youtube-video-css@1.0.0':
+    resolution: {integrity: sha512-zNbXax+t783aHfl47oST5l/jsz18DdQ3nZP6z5wUl5LHyC3IR/29slu4zl2cTps9KdB8BPCpW1xQj+LMQyRhFg==}
 
   '@vitejs/plugin-basic-ssl@1.2.0':
     resolution: {integrity: sha512-mkQnxTkcldAzIsomk1UuLfAu9n+kpQ3JbHcpCp7d2Oo6ITtji8pHS3QToOWjhPFvNQSnhlkAjmGbhv2QvwO/7Q==}
@@ -14256,7 +14295,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@19.2.0(@angular/compiler-cli@19.2.0(@angular/compiler@19.2.0(@angular/core@19.2.0(rxjs@7.8.0)(zone.js@0.15.0)))(typescript@5.7.2))(@angular/compiler@19.2.0(@angular/core@19.2.0(rxjs@7.8.0)(zone.js@0.15.0)))(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@20.17.6)(chokidar@4.0.1)(html-webpack-plugin@5.6.3(webpack@5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))))(jest-environment-jsdom@29.7.0)(jest@29.7.0(@types/node@20.17.6))(jiti@1.21.7)(karma@6.4.0)(ng-packagr@19.2.0(@angular/compiler-cli@19.2.0(@angular/compiler@19.2.0(@angular/core@19.2.0(rxjs@7.8.0)(zone.js@0.15.0)))(typescript@5.7.2))(tslib@2.3.0)(typescript@5.7.2))(typescript@5.7.2)(vite@6.1.0(@types/node@20.17.6)(jiti@1.21.7)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(yaml@2.7.0))(yaml@2.7.0)':
+  '@angular-devkit/build-angular@19.2.0(@angular/compiler-cli@19.2.0(@angular/compiler@19.2.0(@angular/core@19.2.0(rxjs@7.8.0)(zone.js@0.15.0)))(typescript@5.7.2))(@angular/compiler@19.2.0(@angular/core@19.2.0(rxjs@7.8.0)(zone.js@0.15.0)))(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@20.17.6)(chokidar@4.0.1)(html-webpack-plugin@5.6.3(webpack@5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.0)))(jest-environment-jsdom@29.7.0)(jest@29.7.0(@types/node@20.17.6))(jiti@1.21.7)(karma@6.4.0)(ng-packagr@19.2.0(@angular/compiler-cli@19.2.0(@angular/compiler@19.2.0(@angular/core@19.2.0(rxjs@7.8.0)(zone.js@0.15.0)))(typescript@5.7.2))(tslib@2.3.0)(typescript@5.7.2))(typescript@5.7.2)(vite@6.1.0(@types/node@20.17.6)(jiti@1.21.7)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(yaml@2.7.0))(yaml@2.7.0)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1902.0(chokidar@4.0.1)
@@ -14314,7 +14353,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.0))
       webpack-dev-server: 5.2.0(webpack@5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.0))
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.3(webpack@5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))))(webpack@5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.0))
+      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.3(webpack@5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.0)))(webpack@5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.0))
     optionalDependencies:
       esbuild: 0.25.0
       jest: 29.7.0(@types/node@20.17.6)
@@ -20634,27 +20673,25 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@utrecht/accordion-css@1.6.0': {}
+  '@utrecht/accordion-css@2.0.0': {}
 
-  '@utrecht/alert-css@2.2.0': {}
+  '@utrecht/alert-css@2.3.0': {}
 
-  '@utrecht/alert-dialog-css@1.4.1': {}
+  '@utrecht/alert-dialog-css@1.4.2': {}
 
-  '@utrecht/alternate-lang-nav-css@1.3.0': {}
+  '@utrecht/alternate-lang-nav-css@1.3.1': {}
 
-  '@utrecht/article-css@1.5.0': {}
+  '@utrecht/article-css@1.5.1': {}
 
-  '@utrecht/backdrop-css@1.4.0': {}
+  '@utrecht/backdrop-css@1.4.1': {}
 
-  '@utrecht/badge-counter-css@1.4.0': {}
+  '@utrecht/badge-counter-css@1.4.1': {}
 
-  '@utrecht/badge-list-css@2.2.0': {}
+  '@utrecht/badge-list-css@2.2.1': {}
 
-  '@utrecht/badge-status-css@1.4.0': {}
+  '@utrecht/badge-status-css@1.4.1': {}
 
-  '@utrecht/blockquote-css@1.6.0': {}
-
-  '@utrecht/body-css@1.2.0': {}
+  '@utrecht/blockquote-css@1.6.1': {}
 
   '@utrecht/body-css@1.2.1': {}
 
@@ -20666,272 +20703,288 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  '@utrecht/breadcrumb-nav-css@1.4.0': {}
+  '@utrecht/breadcrumb-nav-css@1.4.1': {}
 
-  '@utrecht/button-css@2.3.0': {}
+  '@utrecht/button-css@2.3.1': {}
 
-  '@utrecht/button-group-css@1.4.0': {}
+  '@utrecht/button-group-css@1.4.1': {}
 
-  '@utrecht/button-group-react@1.0.0(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@utrecht/button-group-react@1.0.1(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.1
-      '@utrecht/button-group-css': 1.4.0
+      '@utrecht/button-group-css': 1.4.1
       clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@utrecht/button-link-css@1.3.0': {}
+  '@utrecht/button-link-css@1.3.1': {}
 
-  '@utrecht/button-react@2.0.6(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@utrecht/button-react@2.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.1
-      '@utrecht/button-css': 2.3.0
+      '@utrecht/button-css': 2.3.1
       clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@utrecht/calendar-css@1.4.0': {}
+  '@utrecht/calendar-css@1.4.1': {}
 
-  '@utrecht/calendar-react@1.0.10(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@utrecht/calendar-react@1.0.11(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.1
-      '@utrecht/button-react': 2.0.6(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@utrecht/calendar-css': 1.4.0
+      '@utrecht/button-react': 2.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/calendar-css': 1.4.1
       clsx: 2.1.1
       date-fns: 2.30.0
       lodash-es: 4.17.21
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@utrecht/checkbox-css@1.6.0': {}
+  '@utrecht/card-css@0.1.0':
+    dependencies:
+      '@utrecht/img-css': 1.3.1
 
-  '@utrecht/checkbox-react@1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@utrecht/card-react@0.0.1(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.1
-      '@utrecht/checkbox-css': 1.6.0
-      '@utrecht/custom-checkbox-css': 1.3.1
+      '@utrecht/card-css': 0.1.0
+      '@utrecht/link-react': 1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@utrecht/code-block-css@1.5.0': {}
+  '@utrecht/checkbox-css@1.6.1': {}
 
-  '@utrecht/code-css@1.5.0': {}
-
-  '@utrecht/color-sample-css@1.4.0': {}
-
-  '@utrecht/column-layout-css@1.5.0': {}
-
-  '@utrecht/combobox-css@1.4.0': {}
-
-  '@utrecht/combobox-react@0.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@utrecht/checkbox-react@1.0.8(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.1
-      '@utrecht/combobox-css': 1.4.0
+      '@utrecht/checkbox-css': 1.6.1
+      '@utrecht/custom-checkbox-css': 1.3.2
       clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@utrecht/component-library-css@7.1.5':
-    dependencies:
-      '@utrecht/accordion-css': 1.6.0
-      '@utrecht/alert-css': 2.2.0
-      '@utrecht/alert-dialog-css': 1.4.1
-      '@utrecht/alternate-lang-nav-css': 1.3.0
-      '@utrecht/article-css': 1.5.0
-      '@utrecht/backdrop-css': 1.4.0
-      '@utrecht/badge-counter-css': 1.4.0
-      '@utrecht/badge-list-css': 2.2.0
-      '@utrecht/badge-status-css': 1.4.0
-      '@utrecht/blockquote-css': 1.6.0
-      '@utrecht/body-css': 1.2.0
-      '@utrecht/breadcrumb-nav-css': 1.4.0
-      '@utrecht/button-css': 2.3.0
-      '@utrecht/button-group-css': 1.4.0
-      '@utrecht/button-link-css': 1.3.0
-      '@utrecht/calendar-css': 1.4.0
-      '@utrecht/checkbox-css': 1.6.0
-      '@utrecht/code-block-css': 1.5.0
-      '@utrecht/code-css': 1.5.0
-      '@utrecht/color-sample-css': 1.4.0
-      '@utrecht/column-layout-css': 1.5.0
-      '@utrecht/combobox-css': 1.4.0
-      '@utrecht/currency-data-css': 1.3.0
-      '@utrecht/custom-checkbox-css': 1.3.1
-      '@utrecht/data-badge-css': 1.0.0
-      '@utrecht/data-list-css': 1.4.0
-      '@utrecht/data-placeholder-css': 1.4.0
-      '@utrecht/digid-button-css': 1.4.0
-      '@utrecht/document-css': 1.5.0
-      '@utrecht/drawer-css': 1.4.0
-      '@utrecht/emphasis-css': 1.5.0
-      '@utrecht/figure-css': 1.5.0
-      '@utrecht/form-css': 1.5.0
-      '@utrecht/form-field-css': 1.5.0
-      '@utrecht/form-field-description-css': 1.5.0
-      '@utrecht/form-field-error-message-css': 1.5.0
-      '@utrecht/form-fieldset-css': 1.5.0
-      '@utrecht/form-label-css': 1.6.0
-      '@utrecht/form-toggle-css': 1.5.0
-      '@utrecht/heading-1-css': 1.5.0
-      '@utrecht/heading-2-css': 1.5.0
-      '@utrecht/heading-3-css': 1.5.0
-      '@utrecht/heading-4-css': 1.5.0
-      '@utrecht/heading-5-css': 1.5.0
-      '@utrecht/heading-6-css': 1.5.0
-      '@utrecht/heading-group-css': 1.5.0
-      '@utrecht/html-content-css': 1.4.0
-      '@utrecht/iban-data-css': 1.3.0
-      '@utrecht/icon-css': 2.0.0
-      '@utrecht/img-css': 1.3.0
-      '@utrecht/index-char-nav-css': 1.4.0
-      '@utrecht/link-button-css': 1.4.0
-      '@utrecht/link-css': 1.6.0
-      '@utrecht/link-list-css': 2.3.0
-      '@utrecht/link-social-css': 1.4.0
-      '@utrecht/list-social-css': 1.4.0
-      '@utrecht/listbox-css': 1.5.1
-      '@utrecht/logo-button-css': 1.4.0
-      '@utrecht/logo-css': 1.4.0
-      '@utrecht/logo-image-css': 1.4.0
-      '@utrecht/map-marker-css': 1.4.0
-      '@utrecht/mark-css': 1.5.0
-      '@utrecht/multiline-data-css': 1.3.0
-      '@utrecht/nav-bar-css': 1.4.0
-      '@utrecht/nav-list-css': 1.3.0
-      '@utrecht/number-badge-css': 2.3.0
-      '@utrecht/number-data-css': 1.4.0
-      '@utrecht/ordered-list-css': 1.5.1
-      '@utrecht/page-body-css': 0.1.0
-      '@utrecht/page-content-css': 1.4.0
-      '@utrecht/page-css': 1.4.0
-      '@utrecht/page-footer-css': 2.1.0
-      '@utrecht/page-header-css': 1.5.0
-      '@utrecht/page-layout-css': 1.1.0
-      '@utrecht/pagination-css': 1.4.0
-      '@utrecht/paragraph-css': 2.3.0
-      '@utrecht/pre-heading-css': 1.4.0
-      '@utrecht/preserve-data-css': 1.3.0
-      '@utrecht/radio-button-css': 1.6.0
-      '@utrecht/rich-text-css': 1.3.0
-      '@utrecht/root-css': 1.2.0
-      '@utrecht/search-bar-css': 2.2.0
-      '@utrecht/select-css': 1.8.0
-      '@utrecht/separator-css': 1.5.0
-      '@utrecht/skip-link-css': 1.5.0
-      '@utrecht/spotlight-section-css': 1.6.0
-      '@utrecht/surface-css': 1.4.0
-      '@utrecht/table-css': 1.6.0
-      '@utrecht/table-of-contents-css': 0.3.0
-      '@utrecht/textarea-css': 2.3.1
-      '@utrecht/textbox-css': 1.7.0
-      '@utrecht/top-task-link-css': 1.4.0
-      '@utrecht/top-task-nav-css': 1.3.0
-      '@utrecht/unordered-list-css': 1.5.0
-      '@utrecht/url-data-css': 1.3.0
+  '@utrecht/code-block-css@1.5.1': {}
 
-  '@utrecht/component-library-react@9.0.6(@babel/runtime@7.27.1)(date-fns@2.30.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@utrecht/code-css@1.5.1': {}
+
+  '@utrecht/color-sample-css@1.4.1': {}
+
+  '@utrecht/column-layout-css@1.5.1': {}
+
+  '@utrecht/combobox-css@1.4.1': {}
+
+  '@utrecht/combobox-react@0.0.8(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.1
-      '@utrecht/accordion-css': 1.6.0
-      '@utrecht/alert-css': 2.2.0
-      '@utrecht/alert-dialog-css': 1.4.1
-      '@utrecht/alternate-lang-nav-css': 1.3.0
-      '@utrecht/article-css': 1.5.0
-      '@utrecht/backdrop-css': 1.4.0
-      '@utrecht/badge-counter-css': 1.4.0
-      '@utrecht/badge-list-css': 2.2.0
-      '@utrecht/badge-status-css': 1.4.0
-      '@utrecht/blockquote-css': 1.6.0
-      '@utrecht/breadcrumb-nav-css': 1.4.0
-      '@utrecht/button-group-react': 1.0.0(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@utrecht/button-link-css': 1.3.0
-      '@utrecht/button-react': 2.0.6(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@utrecht/calendar-react': 1.0.10(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@utrecht/checkbox-react': 1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@utrecht/code-block-css': 1.5.0
-      '@utrecht/code-css': 1.5.0
-      '@utrecht/color-sample-css': 1.4.0
-      '@utrecht/column-layout-css': 1.5.0
-      '@utrecht/combobox-react': 0.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@utrecht/currency-data-css': 1.3.0
-      '@utrecht/custom-checkbox-css': 1.3.1
-      '@utrecht/data-badge-css': 1.0.0
-      '@utrecht/data-badge-react': 1.0.3(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@utrecht/data-list-css': 1.4.0
-      '@utrecht/data-placeholder-css': 1.4.0
-      '@utrecht/digid-button-css': 1.4.0
-      '@utrecht/document-css': 1.5.0
-      '@utrecht/drawer-css': 1.4.0
-      '@utrecht/emphasis-css': 1.5.0
-      '@utrecht/fieldset-react': 1.0.6(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@utrecht/figure-css': 1.5.0
-      '@utrecht/focus-ring-css': 2.3.0
-      '@utrecht/form-field-checkbox-react': 1.0.9(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@utrecht/form-field-description-react': 1.0.6(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@utrecht/form-field-error-message-react': 1.0.6(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@utrecht/form-field-react': 1.0.6(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@utrecht/form-label-react': 1.0.6(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@utrecht/form-toggle-css': 1.5.0
-      '@utrecht/heading-1-css': 1.5.0
-      '@utrecht/heading-2-css': 1.5.0
-      '@utrecht/heading-3-css': 1.5.0
-      '@utrecht/heading-4-css': 1.5.0
-      '@utrecht/heading-5-css': 1.5.0
-      '@utrecht/heading-6-css': 1.5.0
-      '@utrecht/heading-group-css': 1.5.0
-      '@utrecht/html-content-css': 1.4.0
-      '@utrecht/iban-data-css': 1.3.0
-      '@utrecht/icon-css': 2.0.0
-      '@utrecht/img-css': 1.3.0
-      '@utrecht/index-char-nav-css': 1.4.0
-      '@utrecht/link-button-css': 1.4.0
-      '@utrecht/link-list-css': 2.3.0
-      '@utrecht/link-react': 1.0.6(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@utrecht/link-social-css': 1.4.0
-      '@utrecht/list-social-css': 1.4.0
-      '@utrecht/listbox-react': 1.0.9(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@utrecht/logo-button-css': 1.4.0
-      '@utrecht/logo-css': 1.4.0
-      '@utrecht/logo-image-css': 1.4.0
-      '@utrecht/map-control-button-css': 2.2.0
-      '@utrecht/map-marker-css': 1.4.0
-      '@utrecht/mark-css': 1.5.0
-      '@utrecht/multiline-data-css': 1.3.0
-      '@utrecht/nav-bar-css': 1.4.0
-      '@utrecht/nav-list-css': 1.3.0
-      '@utrecht/number-badge-css': 2.3.0
-      '@utrecht/number-data-css': 1.4.0
-      '@utrecht/open-forms-container-css': 1.0.0
-      '@utrecht/open-forms-container-react': 1.0.0(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@utrecht/ordered-list-css': 1.5.1
-      '@utrecht/page-content-css': 1.4.0
-      '@utrecht/page-css': 1.4.0
-      '@utrecht/page-footer-css': 2.1.0
-      '@utrecht/page-header-css': 1.5.0
-      '@utrecht/pagination-css': 1.4.0
-      '@utrecht/paragraph-css': 2.3.0
-      '@utrecht/pre-heading-css': 1.4.0
-      '@utrecht/preserve-data-css': 1.3.0
-      '@utrecht/radio-button-react': 1.0.6(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@utrecht/rich-text-css': 1.3.0
-      '@utrecht/search-bar-css': 2.2.0
-      '@utrecht/select-css': 1.8.0
-      '@utrecht/separator-css': 1.5.0
-      '@utrecht/skip-link-css': 1.5.0
-      '@utrecht/spotlight-section-css': 1.6.0
-      '@utrecht/subscript-css': 1.3.0
-      '@utrecht/superscript-css': 1.3.0
-      '@utrecht/surface-css': 1.4.0
-      '@utrecht/table-css': 1.6.0
-      '@utrecht/table-of-contents-css': 0.3.0
-      '@utrecht/textarea-css': 2.3.1
-      '@utrecht/textbox-react': 1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@utrecht/top-task-link-css': 1.4.0
-      '@utrecht/top-task-nav-css': 1.3.0
-      '@utrecht/unordered-list-css': 1.5.0
-      '@utrecht/url-data-css': 1.3.0
-      '@utrecht/vega-visualization-css': 1.4.0
+      '@utrecht/combobox-css': 1.4.1
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@utrecht/component-library-css@7.2.1':
+    dependencies:
+      '@utrecht/accordion-css': 2.0.0
+      '@utrecht/alert-css': 2.3.0
+      '@utrecht/alert-dialog-css': 1.4.2
+      '@utrecht/alternate-lang-nav-css': 1.3.1
+      '@utrecht/article-css': 1.5.1
+      '@utrecht/backdrop-css': 1.4.1
+      '@utrecht/badge-counter-css': 1.4.1
+      '@utrecht/badge-list-css': 2.2.1
+      '@utrecht/badge-status-css': 1.4.1
+      '@utrecht/blockquote-css': 1.6.1
+      '@utrecht/body-css': 1.2.1
+      '@utrecht/breadcrumb-nav-css': 1.4.1
+      '@utrecht/button-css': 2.3.1
+      '@utrecht/button-group-css': 1.4.1
+      '@utrecht/button-link-css': 1.3.1
+      '@utrecht/calendar-css': 1.4.1
+      '@utrecht/checkbox-css': 1.6.1
+      '@utrecht/code-block-css': 1.5.1
+      '@utrecht/code-css': 1.5.1
+      '@utrecht/color-sample-css': 1.4.1
+      '@utrecht/column-layout-css': 1.5.1
+      '@utrecht/combobox-css': 1.4.1
+      '@utrecht/currency-data-css': 1.3.1
+      '@utrecht/custom-checkbox-css': 1.3.2
+      '@utrecht/data-badge-css': 1.0.1
+      '@utrecht/data-list-css': 1.4.1
+      '@utrecht/data-placeholder-css': 1.4.1
+      '@utrecht/digid-button-css': 1.4.1
+      '@utrecht/document-css': 1.5.1
+      '@utrecht/drawer-css': 1.4.1
+      '@utrecht/emphasis-css': 1.5.1
+      '@utrecht/figure-css': 1.5.1
+      '@utrecht/form-css': 1.5.1
+      '@utrecht/form-field-css': 1.5.1
+      '@utrecht/form-field-description-css': 1.5.1
+      '@utrecht/form-field-error-message-css': 1.5.1
+      '@utrecht/form-fieldset-css': 1.5.1
+      '@utrecht/form-label-css': 1.6.1
+      '@utrecht/form-toggle-css': 1.5.1
+      '@utrecht/heading-1-css': 1.5.1
+      '@utrecht/heading-2-css': 1.5.1
+      '@utrecht/heading-3-css': 1.5.1
+      '@utrecht/heading-4-css': 1.5.1
+      '@utrecht/heading-5-css': 1.5.1
+      '@utrecht/heading-6-css': 1.5.1
+      '@utrecht/heading-group-css': 1.5.1
+      '@utrecht/html-content-css': 1.4.1
+      '@utrecht/iban-data-css': 1.3.1
+      '@utrecht/icon-css': 2.0.1
+      '@utrecht/img-css': 1.3.1
+      '@utrecht/index-char-nav-css': 1.4.1
+      '@utrecht/link-button-css': 1.4.1
+      '@utrecht/link-css': 1.6.1
+      '@utrecht/link-list-css': 2.3.1
+      '@utrecht/link-social-css': 1.4.1
+      '@utrecht/list-social-css': 1.4.1
+      '@utrecht/listbox-css': 1.5.2
+      '@utrecht/logo-button-css': 1.4.1
+      '@utrecht/logo-css': 1.4.1
+      '@utrecht/logo-image-css': 1.4.1
+      '@utrecht/map-marker-css': 1.4.1
+      '@utrecht/mark-css': 1.5.1
+      '@utrecht/multiline-data-css': 1.3.1
+      '@utrecht/nav-bar-css': 1.4.1
+      '@utrecht/nav-list-css': 1.3.1
+      '@utrecht/number-badge-css': 2.3.1
+      '@utrecht/number-data-css': 1.4.1
+      '@utrecht/ordered-list-css': 1.5.2
+      '@utrecht/page-body-css': 0.1.1
+      '@utrecht/page-content-css': 1.4.1
+      '@utrecht/page-css': 1.4.1
+      '@utrecht/page-footer-css': 2.1.1
+      '@utrecht/page-header-css': 1.5.1
+      '@utrecht/page-layout-css': 1.1.1
+      '@utrecht/pagination-css': 1.4.1
+      '@utrecht/paragraph-css': 2.3.1
+      '@utrecht/pre-heading-css': 1.4.1
+      '@utrecht/preserve-data-css': 1.3.1
+      '@utrecht/radio-button-css': 1.6.1
+      '@utrecht/rich-text-css': 1.3.1
+      '@utrecht/root-css': 1.2.1
+      '@utrecht/search-bar-css': 2.2.1
+      '@utrecht/select-css': 1.8.1
+      '@utrecht/separator-css': 1.5.1
+      '@utrecht/skip-link-css': 1.5.1
+      '@utrecht/spotlight-section-css': 1.6.1
+      '@utrecht/surface-css': 1.4.1
+      '@utrecht/table-css': 1.6.1
+      '@utrecht/table-of-contents-css': 0.3.1
+      '@utrecht/textarea-css': 2.3.2
+      '@utrecht/textbox-css': 1.7.1
+      '@utrecht/top-task-link-css': 1.4.1
+      '@utrecht/top-task-nav-css': 1.3.1
+      '@utrecht/unordered-list-css': 1.5.1
+      '@utrecht/url-data-css': 1.3.1
+      '@utrecht/youtube-video-css': 1.0.0
+
+  '@utrecht/component-library-react@10.1.0(@babel/runtime@7.27.1)(date-fns@2.30.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.27.1
+      '@utrecht/accordion-css': 2.0.0
+      '@utrecht/alert-css': 2.3.0
+      '@utrecht/alert-dialog-css': 1.4.2
+      '@utrecht/alternate-lang-nav-css': 1.3.1
+      '@utrecht/article-css': 1.5.1
+      '@utrecht/backdrop-css': 1.4.1
+      '@utrecht/badge-counter-css': 1.4.1
+      '@utrecht/badge-list-css': 2.2.1
+      '@utrecht/badge-status-css': 1.4.1
+      '@utrecht/blockquote-css': 1.6.1
+      '@utrecht/breadcrumb-nav-css': 1.4.1
+      '@utrecht/button-group-react': 1.0.1(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/button-link-css': 1.3.1
+      '@utrecht/button-react': 2.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/calendar-react': 1.0.11(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/card-css': 0.1.0
+      '@utrecht/card-react': 0.0.1(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/checkbox-react': 1.0.8(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/code-block-css': 1.5.1
+      '@utrecht/code-css': 1.5.1
+      '@utrecht/color-sample-css': 1.4.1
+      '@utrecht/column-layout-css': 1.5.1
+      '@utrecht/combobox-react': 0.0.8(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/currency-data-css': 1.3.1
+      '@utrecht/custom-checkbox-css': 1.3.2
+      '@utrecht/data-badge-css': 1.0.1
+      '@utrecht/data-badge-react': 1.0.4(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/data-list-css': 1.4.1
+      '@utrecht/data-placeholder-css': 1.4.1
+      '@utrecht/digid-button-css': 1.4.1
+      '@utrecht/document-css': 1.5.1
+      '@utrecht/drawer-css': 1.4.1
+      '@utrecht/emphasis-css': 1.5.1
+      '@utrecht/fieldset-react': 1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/figure-css': 1.5.1
+      '@utrecht/focus-ring-css': 2.3.1
+      '@utrecht/form-field-checkbox-react': 1.0.10(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/form-field-description-react': 1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/form-field-error-message-react': 1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/form-field-react': 1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/form-label-react': 1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/form-toggle-css': 1.5.1
+      '@utrecht/heading-1-css': 1.5.1
+      '@utrecht/heading-2-css': 1.5.1
+      '@utrecht/heading-3-css': 1.5.1
+      '@utrecht/heading-4-css': 1.5.1
+      '@utrecht/heading-5-css': 1.5.1
+      '@utrecht/heading-6-css': 1.5.1
+      '@utrecht/heading-group-css': 1.5.1
+      '@utrecht/html-content-css': 1.4.1
+      '@utrecht/iban-data-css': 1.3.1
+      '@utrecht/icon-css': 2.0.1
+      '@utrecht/img-css': 1.3.1
+      '@utrecht/index-char-nav-css': 1.4.1
+      '@utrecht/link-button-css': 1.4.1
+      '@utrecht/link-list-css': 2.3.1
+      '@utrecht/link-react': 1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/link-social-css': 1.4.1
+      '@utrecht/list-social-css': 1.4.1
+      '@utrecht/listbox-react': 1.0.10(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/logo-button-css': 1.4.1
+      '@utrecht/logo-css': 1.4.1
+      '@utrecht/logo-image-css': 1.4.1
+      '@utrecht/map-control-button-css': 2.2.1
+      '@utrecht/map-marker-css': 1.4.1
+      '@utrecht/mark-css': 1.5.1
+      '@utrecht/multiline-data-css': 1.3.1
+      '@utrecht/nav-bar-css': 1.4.1
+      '@utrecht/nav-list-css': 1.3.1
+      '@utrecht/number-badge-css': 2.3.1
+      '@utrecht/number-data-css': 1.4.1
+      '@utrecht/open-forms-container-css': 1.0.1
+      '@utrecht/open-forms-container-react': 1.0.1(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/ordered-list-css': 1.5.2
+      '@utrecht/page-content-css': 1.4.1
+      '@utrecht/page-css': 1.4.1
+      '@utrecht/page-footer-css': 2.1.1
+      '@utrecht/page-header-css': 1.5.1
+      '@utrecht/pagination-css': 1.4.1
+      '@utrecht/paragraph-css': 2.3.1
+      '@utrecht/pre-heading-css': 1.4.1
+      '@utrecht/preserve-data-css': 1.3.1
+      '@utrecht/radio-button-react': 1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/rich-text-css': 1.3.1
+      '@utrecht/search-bar-css': 2.2.1
+      '@utrecht/select-css': 1.8.1
+      '@utrecht/separator-css': 1.5.1
+      '@utrecht/skip-link-css': 1.5.1
+      '@utrecht/spotlight-section-css': 1.6.1
+      '@utrecht/subscript-css': 1.3.1
+      '@utrecht/superscript-css': 1.3.1
+      '@utrecht/surface-css': 1.4.1
+      '@utrecht/table-css': 1.6.1
+      '@utrecht/table-of-contents-css': 0.3.1
+      '@utrecht/textarea-css': 2.3.2
+      '@utrecht/textbox-react': 1.0.8(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/top-task-link-css': 1.4.1
+      '@utrecht/top-task-nav-css': 1.3.1
+      '@utrecht/unordered-list-css': 1.5.1
+      '@utrecht/url-data-css': 1.3.1
+      '@utrecht/vega-visualization-css': 1.4.1
       clsx: 2.1.1
       lodash.chunk: 4.2.0
       react: 19.1.0
@@ -20943,131 +20996,133 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
-  '@utrecht/currency-data-css@1.3.0': {}
+  '@utrecht/currency-data-css@1.3.1': {}
 
-  '@utrecht/custom-checkbox-css@1.3.1': {}
+  '@utrecht/custom-checkbox-css@1.3.2': {}
 
-  '@utrecht/data-badge-css@1.0.0': {}
+  '@utrecht/data-badge-css@1.0.1': {}
 
-  '@utrecht/data-badge-react@1.0.3(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@utrecht/data-badge-react@1.0.4(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.1
-      '@utrecht/data-badge-css': 1.0.0
+      '@utrecht/data-badge-css': 1.0.1
       clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@utrecht/data-list-css@1.4.0': {}
+  '@utrecht/data-list-css@1.4.1': {}
 
-  '@utrecht/data-placeholder-css@1.4.0': {}
+  '@utrecht/data-placeholder-css@1.4.1': {}
 
-  '@utrecht/digid-button-css@1.4.0': {}
+  '@utrecht/digid-button-css@1.4.1': {}
 
-  '@utrecht/document-css@1.5.0': {}
+  '@utrecht/document-css@1.5.1': {}
 
-  '@utrecht/drawer-css@1.4.0': {}
+  '@utrecht/drawer-css@1.4.1': {}
 
-  '@utrecht/emphasis-css@1.5.0': {}
+  '@utrecht/emphasis-css@1.5.1': {}
 
-  '@utrecht/fieldset-react@1.0.6(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@utrecht/fieldset-react@1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.1
-      '@utrecht/form-fieldset-css': 1.5.0
+      '@utrecht/form-fieldset-css': 1.5.1
       clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@utrecht/figure-css@1.5.0': {}
+  '@utrecht/figure-css@1.5.1': {}
 
-  '@utrecht/focus-ring-css@2.3.0': {}
+  '@utrecht/focus-ring-css@2.3.1': {}
 
-  '@utrecht/form-css@1.5.0': {}
+  '@utrecht/form-css@1.5.1': {}
 
-  '@utrecht/form-field-checkbox-react@1.0.9(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@utrecht/form-field-checkbox-react@1.0.10(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.1
-      '@utrecht/checkbox-react': 1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@utrecht/form-field-description-react': 1.0.6(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@utrecht/form-field-error-message-react': 1.0.6(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@utrecht/form-field-react': 1.0.6(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@utrecht/form-label-react': 1.0.6(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/checkbox-react': 1.0.8(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/form-field-description-react': 1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/form-field-error-message-react': 1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/form-field-react': 1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@utrecht/form-label-react': 1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@utrecht/form-field-css@1.5.0': {}
+  '@utrecht/form-field-css@1.5.1': {}
 
-  '@utrecht/form-field-description-css@1.5.0': {}
+  '@utrecht/form-field-description-css@1.5.1': {}
 
-  '@utrecht/form-field-description-react@1.0.6(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@utrecht/form-field-description-react@1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.1
-      '@utrecht/form-field-description-css': 1.5.0
+      '@utrecht/form-field-description-css': 1.5.1
       clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@utrecht/form-field-error-message-css@1.5.0': {}
+  '@utrecht/form-field-error-message-css@1.5.1': {}
 
-  '@utrecht/form-field-error-message-react@1.0.6(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@utrecht/form-field-error-message-react@1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.1
-      '@utrecht/form-field-error-message-css': 1.5.0
+      '@utrecht/form-field-error-message-css': 1.5.1
       clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@utrecht/form-field-react@1.0.6(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@utrecht/form-field-react@1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.1
-      '@utrecht/form-field-css': 1.5.0
+      '@utrecht/form-field-css': 1.5.1
       clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@utrecht/form-fieldset-css@1.5.0': {}
+  '@utrecht/form-fieldset-css@1.5.1': {}
 
-  '@utrecht/form-label-css@1.6.0': {}
+  '@utrecht/form-label-css@1.6.1': {}
 
-  '@utrecht/form-label-react@1.0.6(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@utrecht/form-label-react@1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.1
-      '@utrecht/form-label-css': 1.6.0
+      '@utrecht/form-label-css': 1.6.1
       clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@utrecht/form-toggle-css@1.5.0': {}
+  '@utrecht/form-toggle-css@1.5.1': {}
 
-  '@utrecht/heading-1-css@1.5.0': {}
+  '@utrecht/heading-1-css@1.5.1': {}
 
-  '@utrecht/heading-2-css@1.5.0': {}
+  '@utrecht/heading-2-css@1.5.1': {}
 
-  '@utrecht/heading-3-css@1.5.0': {}
+  '@utrecht/heading-3-css@1.5.1': {}
 
-  '@utrecht/heading-4-css@1.5.0': {}
+  '@utrecht/heading-4-css@1.5.1': {}
 
-  '@utrecht/heading-5-css@1.5.0': {}
+  '@utrecht/heading-5-css@1.5.1': {}
 
-  '@utrecht/heading-6-css@1.5.0': {}
+  '@utrecht/heading-6-css@1.5.1': {}
 
-  '@utrecht/heading-group-css@1.5.0': {}
+  '@utrecht/heading-group-css@1.5.1': {}
 
-  '@utrecht/html-content-css@1.4.0': {}
+  '@utrecht/html-content-css@1.4.1': {}
 
-  '@utrecht/iban-data-css@1.3.0': {}
+  '@utrecht/iban-data-css@1.3.1': {}
 
-  '@utrecht/icon-css@2.0.0': {}
+  '@utrecht/icon-css@2.0.1': {}
 
-  '@utrecht/img-css@1.3.0': {}
+  '@utrecht/img-css@1.3.1': {}
 
-  '@utrecht/index-char-nav-css@1.4.0': {}
+  '@utrecht/index-char-nav-css@1.4.1': {}
 
-  '@utrecht/link-button-css@1.4.0': {}
+  '@utrecht/link-button-css@1.4.1': {}
 
   '@utrecht/link-css@1.6.0': {}
 
-  '@utrecht/link-list-css@2.3.0': {}
+  '@utrecht/link-css@1.6.1': {}
+
+  '@utrecht/link-list-css@2.3.1': {}
 
   '@utrecht/link-react@1.0.6(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -21077,58 +21132,68 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@utrecht/link-social-css@1.4.0': {}
-
-  '@utrecht/list-social-css@1.4.0': {}
-
-  '@utrecht/listbox-css@1.5.1': {}
-
-  '@utrecht/listbox-react@1.0.9(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@utrecht/link-react@1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.1
-      '@utrecht/listbox-css': 1.5.1
+      '@utrecht/link-css': 1.6.1
       clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@utrecht/logo-button-css@1.4.0': {}
+  '@utrecht/link-social-css@1.4.1': {}
 
-  '@utrecht/logo-css@1.4.0': {}
+  '@utrecht/list-social-css@1.4.1': {}
 
-  '@utrecht/logo-image-css@1.4.0': {}
+  '@utrecht/listbox-css@1.5.2': {}
 
-  '@utrecht/map-control-button-css@2.2.0': {}
-
-  '@utrecht/map-marker-css@1.4.0': {}
-
-  '@utrecht/mark-css@1.5.0': {}
-
-  '@utrecht/multiline-data-css@1.3.0': {}
-
-  '@utrecht/nav-bar-css@1.4.0': {}
-
-  '@utrecht/nav-list-css@1.3.0': {}
-
-  '@utrecht/number-badge-css@2.3.0': {}
-
-  '@utrecht/number-data-css@1.4.0': {}
-
-  '@utrecht/open-forms-container-css@1.0.0':
-    dependencies:
-      '@utrecht/focus-ring-css': 2.3.0
-      '@utrecht/textbox-css': 1.7.0
-
-  '@utrecht/open-forms-container-react@1.0.0(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@utrecht/listbox-react@1.0.10(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.1
-      '@utrecht/open-forms-container-css': 1.0.0
+      '@utrecht/listbox-css': 1.5.2
       clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@utrecht/ordered-list-css@1.5.1': {}
+  '@utrecht/logo-button-css@1.4.1': {}
+
+  '@utrecht/logo-css@1.4.1': {}
+
+  '@utrecht/logo-image-css@1.4.1': {}
+
+  '@utrecht/map-control-button-css@2.2.1': {}
+
+  '@utrecht/map-marker-css@1.4.1': {}
+
+  '@utrecht/mark-css@1.5.1': {}
+
+  '@utrecht/multiline-data-css@1.3.1': {}
+
+  '@utrecht/nav-bar-css@1.4.1': {}
+
+  '@utrecht/nav-list-css@1.3.1': {}
+
+  '@utrecht/number-badge-css@2.3.1': {}
+
+  '@utrecht/number-data-css@1.4.1': {}
+
+  '@utrecht/open-forms-container-css@1.0.1':
+    dependencies:
+      '@utrecht/focus-ring-css': 2.3.1
+      '@utrecht/textbox-css': 1.7.1
+
+  '@utrecht/open-forms-container-react@1.0.1(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.27.1
+      '@utrecht/open-forms-container-css': 1.0.1
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@utrecht/ordered-list-css@1.5.2': {}
 
   '@utrecht/page-body-css@0.1.0': {}
+
+  '@utrecht/page-body-css@0.1.1': {}
 
   '@utrecht/page-body-react@1.0.5(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -21138,15 +21203,17 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@utrecht/page-content-css@1.4.0': {}
+  '@utrecht/page-content-css@1.4.1': {}
 
-  '@utrecht/page-css@1.4.0': {}
+  '@utrecht/page-css@1.4.1': {}
 
-  '@utrecht/page-footer-css@2.1.0': {}
+  '@utrecht/page-footer-css@2.1.1': {}
 
-  '@utrecht/page-header-css@1.5.0': {}
+  '@utrecht/page-header-css@1.5.1': {}
 
   '@utrecht/page-layout-css@1.1.0': {}
+
+  '@utrecht/page-layout-css@1.1.1': {}
 
   '@utrecht/page-layout-react@1.0.5(@babel/runtime@7.27.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
@@ -21164,15 +21231,17 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@utrecht/pagination-css@1.4.0': {}
+  '@utrecht/pagination-css@1.4.1': {}
 
-  '@utrecht/paragraph-css@2.3.0': {}
+  '@utrecht/paragraph-css@2.3.1': {}
 
-  '@utrecht/pre-heading-css@1.4.0': {}
+  '@utrecht/pre-heading-css@1.4.1': {}
 
-  '@utrecht/preserve-data-css@1.3.0': {}
+  '@utrecht/preserve-data-css@1.3.1': {}
 
   '@utrecht/radio-button-css@1.6.0': {}
+
+  '@utrecht/radio-button-css@1.6.1': {}
 
   '@utrecht/radio-button-react@1.0.6(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -21182,9 +21251,19 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@utrecht/rich-text-css@1.3.0': {}
+  '@utrecht/radio-button-react@1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.27.1
+      '@utrecht/radio-button-css': 1.6.1
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@utrecht/rich-text-css@1.3.1': {}
 
   '@utrecht/root-css@1.2.0': {}
+
+  '@utrecht/root-css@1.2.1': {}
 
   '@utrecht/root-react@1.0.5(@babel/runtime@7.27.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
@@ -21202,47 +21281,47 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@utrecht/search-bar-css@2.2.0': {}
+  '@utrecht/search-bar-css@2.2.1': {}
 
-  '@utrecht/select-css@1.8.0': {}
+  '@utrecht/select-css@1.8.1': {}
 
-  '@utrecht/separator-css@1.5.0': {}
+  '@utrecht/separator-css@1.5.1': {}
 
-  '@utrecht/skip-link-css@1.5.0': {}
+  '@utrecht/skip-link-css@1.5.1': {}
 
-  '@utrecht/spotlight-section-css@1.6.0': {}
+  '@utrecht/spotlight-section-css@1.6.1': {}
 
-  '@utrecht/subscript-css@1.3.0': {}
+  '@utrecht/subscript-css@1.3.1': {}
 
-  '@utrecht/superscript-css@1.3.0': {}
+  '@utrecht/superscript-css@1.3.1': {}
 
-  '@utrecht/surface-css@1.4.0': {}
+  '@utrecht/surface-css@1.4.1': {}
 
-  '@utrecht/table-css@1.6.0': {}
+  '@utrecht/table-css@1.6.1': {}
 
-  '@utrecht/table-of-contents-css@0.3.0': {}
+  '@utrecht/table-of-contents-css@0.3.1': {}
 
-  '@utrecht/textarea-css@2.3.1': {}
+  '@utrecht/textarea-css@2.3.2': {}
 
-  '@utrecht/textbox-css@1.7.0': {}
+  '@utrecht/textbox-css@1.7.1': {}
 
-  '@utrecht/textbox-react@1.0.7(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@utrecht/textbox-react@1.0.8(@babel/runtime@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.1
-      '@utrecht/textbox-css': 1.7.0
+      '@utrecht/textbox-css': 1.7.1
       clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@utrecht/top-task-link-css@1.4.0': {}
+  '@utrecht/top-task-link-css@1.4.1': {}
 
-  '@utrecht/top-task-nav-css@1.3.0': {}
+  '@utrecht/top-task-nav-css@1.3.1': {}
 
-  '@utrecht/unordered-list-css@1.5.0': {}
+  '@utrecht/unordered-list-css@1.5.1': {}
 
-  '@utrecht/url-data-css@1.3.0': {}
+  '@utrecht/url-data-css@1.3.1': {}
 
-  '@utrecht/vega-visualization-css@1.4.0': {}
+  '@utrecht/vega-visualization-css@1.4.1': {}
 
   '@utrecht/web-component-library-react@3.0.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -21253,6 +21332,8 @@ snapshots:
   '@utrecht/web-component-library-stencil@3.4.0':
     dependencies:
       '@stencil/core': 4.18.3
+
+  '@utrecht/youtube-video-css@1.0.0': {}
 
   '@vitejs/plugin-basic-ssl@1.2.0(vite@6.1.0(@types/node@20.17.6)(jiti@1.21.7)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(yaml@2.7.0))':
     dependencies:
@@ -25036,17 +25117,7 @@ snapshots:
 
   html-tags@3.3.1: {}
 
-  html-webpack-plugin@5.6.3(webpack@5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.1)):
-    dependencies:
-      '@types/html-minifier-terser': 6.1.0
-      html-minifier-terser: 6.1.0
-      lodash: 4.17.21
-      pretty-error: 4.0.0
-      tapable: 2.2.1
-    optionalDependencies:
-      webpack: 5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.1)
-
-  html-webpack-plugin@5.6.3(webpack@5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))):
+  html-webpack-plugin@5.6.3(webpack@5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.0)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -25056,6 +25127,16 @@ snapshots:
     optionalDependencies:
       webpack: 5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.0)
     optional: true
+
+  html-webpack-plugin@5.6.3(webpack@5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.1)):
+    dependencies:
+      '@types/html-minifier-terser': 6.1.0
+      html-minifier-terser: 6.1.0
+      lodash: 4.17.21
+      pretty-error: 4.0.0
+      tapable: 2.2.1
+    optionalDependencies:
+      webpack: 5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.1)
 
   htmlparser2@3.10.1:
     dependencies:
@@ -27511,7 +27592,7 @@ snapshots:
     dependencies:
       type-fest: 2.19.0
 
-  next@15.2.0(@babel/core@7.27.1)(@playwright/test@1.52.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.87.0):
+  next@15.2.0(@playwright/test@1.52.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.87.0):
     dependencies:
       '@next/env': 15.2.0
       '@swc/counter': 0.1.3
@@ -27521,7 +27602,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      styled-jsx: 5.1.6(@babel/core@7.27.1)(react@19.0.0)
+      styled-jsx: 5.1.6(react@19.0.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.2.0
       '@next/swc-darwin-x64': 15.2.0
@@ -30327,19 +30408,17 @@ snapshots:
     dependencies:
       webpack: 5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.1)
 
-  styled-jsx@5.1.6(@babel/core@7.27.1)(react@19.0.0):
-    dependencies:
-      client-only: 0.0.1
-      react: 19.0.0
-    optionalDependencies:
-      '@babel/core': 7.27.1
-
   styled-jsx@5.1.6(@babel/core@7.27.1)(react@19.1.0):
     dependencies:
       client-only: 0.0.1
       react: 19.1.0
     optionalDependencies:
       '@babel/core': 7.27.1
+
+  styled-jsx@5.1.6(react@19.0.0):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.0.0
 
   stylehacks@5.1.1(postcss@8.5.3):
     dependencies:
@@ -31437,19 +31516,19 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
+  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.3(webpack@5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.0)))(webpack@5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.0)):
+    dependencies:
+      typed-assert: 1.0.9
+      webpack: 5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.0)
+    optionalDependencies:
+      html-webpack-plugin: 5.6.3(webpack@5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.0))
+
   webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.3(webpack@5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.1)))(webpack@5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.1)):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.1)
     optionalDependencies:
       html-webpack-plugin: 5.6.3(webpack@5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.1))
-
-  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.3(webpack@5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))))(webpack@5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.0)):
-    dependencies:
-      typed-assert: 1.0.9
-      webpack: 5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.25.0)
-    optionalDependencies:
-      html-webpack-plugin: 5.6.3(webpack@5.98.0(@swc/core@1.10.1(@swc/helpers@0.5.15)))
 
   webpack-virtual-modules@0.6.2: {}
 


### PR DESCRIPTION
Update dependencies `@utrecht/component-library-css` and `@utrecht/component-library-react` in order to use the updated `role` and `type` logic in Utrecht Alert component. Does not require change in our usage of Alert.

**@utrecht/component-library-css** from 7.1.5 to 7.2.1
According to [changelog](https://github.com/nl-design-system/utrecht/blob/main/packages/component-library-css/CHANGELOG.md) this is safe to update, includes:
- patch updates, including Alert update
- Add YouTube video CSS component

**@utrecht/component-library-css** from 9.0.6 to 10.1.0
According to [changelog](https://github.com/nl-design-system/utrecht/blob/main/packages/component-library-react/CHANGELOG.md) this is safe to update, includes:
- patch updates
- Alert update
- Deprecated `utrecht-accordion__button--utrecht` which we don't use 