### PR TITLE
Storybook composition

### DIFF
--- a/packages/storybook-angular/src/stories/action-group.stories.ts
+++ b/packages/storybook-angular/src/stories/action-group.stories.ts
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/angular';
 import { ActionGroupComponent, ButtonComponent } from '../../../components-angular/src/public-api';
 
 const meta: Meta<ActionGroupComponent> = {
-  title: 'Rijkshuisstijl-angular/Action Group',
+  title: 'Rijkshuisstijl/Action Group',
   id: 'rhc-angular-action-group',
   component: ActionGroupComponent,
   argTypes: {

--- a/packages/storybook-angular/src/stories/button.stories.ts
+++ b/packages/storybook-angular/src/stories/button.stories.ts
@@ -3,7 +3,7 @@ import readme from './button.md';
 import { ButtonComponent, IconComponent } from '../../../components-angular/src/public-api';
 
 const meta: Meta<ButtonComponent> = {
-  title: 'Rijkshuisstijl-angular/Button',
+  title: 'Rijkshuisstijl/Button',
   id: 'rhc-angular-button',
   component: ButtonComponent,
   argTypes: {

--- a/packages/storybook-angular/src/stories/column-layout.stories.ts
+++ b/packages/storybook-angular/src/stories/column-layout.stories.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../components-angular/src/public-api';
 
 const meta: Meta<ColumnLayoutComponent> = {
-  title: 'Rijkshuisstijl-angular/Column layout',
+  title: 'Rijkshuisstijl/Column layout',
   id: 'rhc-angular-column-layout',
   component: ColumnLayoutComponent,
   argTypes: {

--- a/packages/storybook-angular/src/stories/figure.stories.ts
+++ b/packages/storybook-angular/src/stories/figure.stories.ts
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/angular';
 import { FigureCaptionComponent, FigureComponent, ImageComponent } from '../../../components-angular/src/public-api';
 
 const meta: Meta<FigureComponent> = {
-  title: 'Rijkshuisstijl-angular/Figure',
+  title: 'Rijkshuisstijl/Figure',
   id: 'rhc-angular-figure',
   component: FigureComponent,
   render: ({ borderEndEndRadius, borderEndStartRadius, borderStartEndRadius, borderStartStartRadius }) => ({

--- a/packages/storybook-angular/src/stories/form-field-text-input.stories.ts
+++ b/packages/storybook-angular/src/stories/form-field-text-input.stories.ts
@@ -3,7 +3,7 @@ import { FormFieldTextInputComponent } from '@rijkshuisstijl-community/component
 import { type Meta, type StoryObj } from '@storybook/angular';
 
 const meta: Meta<FormFieldTextInputComponent> = {
-  title: 'Rijkshuisstijl-angular/Form field text input',
+  title: 'Rijkshuisstijl/Form field text input',
   id: 'rhc-angular-form-field-text-input',
   component: FormFieldTextInputComponent,
   argTypes: {

--- a/packages/storybook-angular/src/stories/heading.stories.ts
+++ b/packages/storybook-angular/src/stories/heading.stories.ts
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/angular';
 import { HeadingComponent, headingLevels } from '../../../components-angular/src/public-api';
 
 const meta: Meta<HeadingComponent> = {
-  title: 'Rijkshuisstijl-angular/Heading',
+  title: 'Rijkshuisstijl/Heading',
   id: 'rhc-angular-heading',
   component: HeadingComponent,
   argTypes: {

--- a/packages/storybook-angular/src/stories/icon.stories.ts
+++ b/packages/storybook-angular/src/stories/icon.stories.ts
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/angular';
 import { IconComponent, NlFlagComponent } from '../../../components-angular/src/public-api';
 
 const meta: Meta<IconComponent> = {
-  title: 'Rijkshuisstijl-angular/Icon',
+  title: 'Rijkshuisstijl/Icon',
   id: 'rhc-angular-icon',
   component: IconComponent,
   argTypes: {

--- a/packages/storybook-angular/src/stories/image.stories.ts
+++ b/packages/storybook-angular/src/stories/image.stories.ts
@@ -4,7 +4,7 @@ import { ImageComponent } from '../../../components-angular/src/public-api';
 type StoryType = ImageComponent & { src: string; alt: string; width: number; height: number };
 
 const meta: Meta<StoryType> = {
-  title: 'Rijkshuisstijl-angular/Image',
+  title: 'Rijkshuisstijl/Image',
   id: 'rhc-angular-image',
   component: ImageComponent,
   argTypes: {

--- a/packages/storybook-angular/src/stories/link-list-link.stories.ts
+++ b/packages/storybook-angular/src/stories/link-list-link.stories.ts
@@ -9,7 +9,7 @@ import {
 type StoryType = LinkListLinkComponent & { label?: string };
 
 const meta: Meta<StoryType> = {
-  title: 'Rijkshuisstijl-angular/Link List/Link list link',
+  title: 'Rijkshuisstijl/Link List/Link list link',
   id: 'rhc-angular-link-list-link',
   component: LinkListLinkComponent,
   decorators: [

--- a/packages/storybook-angular/src/stories/link-list.stories.ts
+++ b/packages/storybook-angular/src/stories/link-list.stories.ts
@@ -11,7 +11,7 @@ import {
 type StoryType = LinkListComponent & { hasIcons?: boolean };
 
 const meta: Meta<StoryType> = {
-  title: 'Rijkshuisstijl-angular/Link list',
+  title: 'Rijkshuisstijl/Link list',
   id: 'rhc-angular-link-list',
   component: LinkListComponent,
   decorators: [

--- a/packages/storybook-angular/src/stories/link.stories.ts
+++ b/packages/storybook-angular/src/stories/link.stories.ts
@@ -7,7 +7,7 @@ const meta: Meta<LinkComponent> = {
       imports: [ParagraphComponent],
     }),
   ],
-  title: 'Rijkshuisstijl-angular/Link',
+  title: 'Rijkshuisstijl/Link',
   id: 'rhc-angular-link',
   component: LinkComponent,
   argTypes: {

--- a/packages/storybook-angular/src/stories/logo.stories.ts
+++ b/packages/storybook-angular/src/stories/logo.stories.ts
@@ -8,7 +8,7 @@ const meta: Meta<LogoComponent> = {
       imports: [DutchMapIconComponent, IconComponent],
     }),
   ],
-  title: 'Rijkshuisstijl-angular/Logo',
+  title: 'Rijkshuisstijl/Logo',
   id: 'rhc-angular-logo',
   component: LogoComponent,
   argTypes: {

--- a/packages/storybook-angular/src/stories/navbar.stories.ts
+++ b/packages/storybook-angular/src/stories/navbar.stories.ts
@@ -8,7 +8,7 @@ import {
 import { type Meta, moduleMetadata, type StoryObj } from '@storybook/angular';
 
 const meta: Meta<NavbarComponent> = {
-  title: 'Rijkshuisstijl-angular/Navbar',
+  title: 'Rijkshuisstijl/Navbar',
   id: 'rhc-navbar',
   component: NavbarComponent,
   decorators: [

--- a/packages/storybook-angular/src/stories/paragraph.stories.ts
+++ b/packages/storybook-angular/src/stories/paragraph.stories.ts
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/angular';
 import { appearanceOptions, ParagraphComponent } from '../../../components-angular/src/public-api';
 
 const meta: Meta<ParagraphComponent> = {
-  title: 'Rijkshuisstijl-angular/Paragraph',
+  title: 'Rijkshuisstijl/Paragraph',
   id: 'rhc-angular-paragraph',
   component: ParagraphComponent,
   argTypes: {

--- a/packages/storybook-angular/src/stories/text-input.stories.ts
+++ b/packages/storybook-angular/src/stories/text-input.stories.ts
@@ -6,7 +6,7 @@ type StoryType = TextInputComponent & {
 };
 
 const meta: Meta<StoryType> = {
-  title: 'Rijkshuisstijl-angular/Text input',
+  title: 'Rijkshuisstijl/Text input',
   id: 'rhc-text-input',
   component: TextInputComponent,
   argTypes: {

--- a/packages/storybook-angular/src/stories/unordered-list.stories.ts
+++ b/packages/storybook-angular/src/stories/unordered-list.stories.ts
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/angular';
 import { UnorderedListComponent, UnorderedListItemComponent } from '../../../components-angular/src/public-api';
 
 const meta: Meta<UnorderedListComponent> = {
-  title: 'Rijkshuisstijl-angular/Unordered list',
+  title: 'Rijkshuisstijl/Unordered list',
   id: 'rhc-angular-unordered-list',
   component: UnorderedListComponent,
   render: () => ({

--- a/packages/storybook/config/main.ts
+++ b/packages/storybook/config/main.ts
@@ -23,6 +23,23 @@ const config: StorybookConfig = {
   docs: {
     autodocs: true,
   },
+  refs: (_, { configType }) => {
+    if (configType === 'DEVELOPMENT') {
+      return {
+        angular: {
+          title: 'Angular Components',
+          url: 'http://localhost:6008',
+        },
+      };
+    } else {
+      return {
+        angular: {
+          title: 'Angular Components',
+          url: 'https://rijkshuisstijl-community-storybook-angular.vercel.app/',
+        },
+      };
+    }
+  },
 };
 
 export default config;


### PR DESCRIPTION
- Storybook composition toegevoegd volgens Utrecht voorbeeld
- alle titles van de Angular comonenten veranderd van: Rijkshuisstijl-angular naar -> Rijkshuisstijl. Omdat als je de storybook runned ze al onder het kopje Angular components komen en het volgens mij wel duidelijk is dat als je de Angular storybook specifiek bekijkt dat het Angular componenten zijn.

Ik heb dit lokaal getest, maar ik weet niet zeker hoe ik kan testen of hij ook de production environment goed pakt, maar ik denk dat dit wel goed gaat, omdat dit een feature uit storybook zelf is en ik de Utrecht code hiervoor als voorbeeld heb genomen.

Closes #1439 