### PR TITLE
feat: add role=status to search result + improve search result text

### DIFF
--- a/packages/storybook/src/templates/componenten/index.tsx
+++ b/packages/storybook/src/templates/componenten/index.tsx
@@ -46,6 +46,16 @@ export default function Componenten() {
     [debouncedSearchTerm, selectedFrameworks],
   );
 
+  const getResultsText = (count: number): string => {
+    if (count === 0) {
+      return 'Geen componenten gevonden';
+    } else if (count === 1) {
+      return '1 component gevonden';
+    } else {
+      return `${count} componenten gevonden`;
+    }
+  };
+
   const handleFrameworkChange = useCallback((framework: string) => {
     setSelectedFrameworks((prev) =>
       prev.includes(framework) ? prev.filter((f) => f !== framework) : [...prev, framework],
@@ -110,16 +120,22 @@ export default function Componenten() {
             <div aria-atomic="true" aria-live="polite" className="rhc-grid-container__right">
               {filteredComponents.length === 0 ? (
                 <>
-                  <Heading appearanceLevel={3} level={2}>
-                    Geen resultaten gevonden
-                  </Heading>
-                  <Paragraph>Probeer andere zoektermen of filters.</Paragraph>
+                  <HeadingGroup>
+                    <Heading appearanceLevel={3} level={2}>
+                      Geen resultaten gevonden
+                    </Heading>
+                    <Paragraph>Probeer andere zoektermen of filters.</Paragraph>
+                  </HeadingGroup>
                 </>
               ) : (
                 <>
-                  <Heading appearanceLevel={3} level={2}>
-                    Zoekresultaten ({filteredComponents.length} componenten gevonden)
-                  </Heading>
+                  <HeadingGroup>
+                    <Heading appearanceLevel={3} level={2}>
+                      Zoekresultaten
+                    </Heading>
+                    <Paragraph role="status">{getResultsText(filteredComponents.length)}</Paragraph>
+                  </HeadingGroup>
+
                   <ol className="rhc-ordered-list">
                     {filteredComponents.map((component) => (
                       <li key={component.heading}>


### PR DESCRIPTION
Issue [#1638 ](https://github.com/nl-design-system/rijkshuisstijl-community/issues/1638)

---

**Toegepast + gecheckt met screenreader ✅**

❓ bij voorlezen van zoekresultaten tijdens het typen wordt niet (altijd?) het hele zoekresultaat voorgelezen maar halverwege onderbroken omdat de tekst in het zoekveld dan voorgelezen wordt.

**Ook:**
Een kleine aanpassing gedaan zodat bij resultaat van 1 component ook daadwerkelijk "1 component gevonden" komt te staan en niet "1 componenten gevonden".