### PR TITLE
Opzet voor nieuwe readme format (#1736)

### DIFF
--- a/packages/components-react/README.md
+++ b/packages/components-react/README.md
@@ -31,8 +31,8 @@ import { Button } from '@rijkshuisstijl-community/components-react';
 
 function App() {
   return (
+    {/* geef alle thema tokens mee an child components voor styling */}
     <div className="rhc-theme">
-      {/* geef alle thema tokens mee an child components */}
       <Button>Click Here!</Button>
     </div>
   );

--- a/packages/components-react/README.md
+++ b/packages/components-react/README.md
@@ -13,45 +13,41 @@ Deze package is onderdeel van het [Rijkshuisstijl Community](https://github.com/
 
 Om de React-componenten van de Rijkshuisstijl-community te gebruiken, installeer je het [components-react npm package](https://www.npmjs.com/package/@rijkshuisstijl-community/components-react).
 
+De React-componenten hebben geen eigen styling. Om de Rijkshuisstijl aan je project toe te voegen, installeer je het [design-tokens npm package](https://www.npmjs.com/package/@rijkshuisstijl-community/design-tokens) en [component css npm package](https://www.npmjs.com/package/@rijkshuisstijl-community/components-css)
+
+> [!NOTE]  
+> Let erop dat je beide de `@rijkshuisstijl-community/design-tokens/dist/index.css` importeert **en** de component een child is van een element waar de `rhc-theme` op is toegepast. Anders zie je de component zonder styling.
+
 ```bash
-npm install --save-dev @rijkshuisstijl-community/components-react
+npm install --save-dev @rijkshuisstijl-community/components-react @rijkshuisstijl-community/components-css @rijkshuisstijl-community/design-tokens
 ```
 
 Dit installeert de React-componenten. Om deze componenten te gebruiken, kun je ze importeren in jouw app.
 
 ```tsx
-'use client'; // Nodig in sommige projecten
-
-import { Button } from '@rijkshuisstijl-community/components-react';
-
-<Button>Click Here!</Button>;
-```
-
-Sommige componenten gebruiken de [useRef](https://react.dev/reference/react/useRef) hook, die alleen werkt in Client
-Componenten. Voeg `"use client"` toe bovenaan het bestand om dit op te lossen.
-
-### Thema toepassen
-
-De React-componenten hebben geen eigen styling. Om de Rijkshuisstijl aan je project toe te voegen, installeer je het [design-tokens npm package](https://www.npmjs.com/package/@rijkshuisstijl-community/design-tokens).
-
-```bash
-npm install --save-dev @rijkshuisstijl-community/design-tokens
-```
-
-Dit pakket bevat de CSS-variabelen van het design systeem. Importeer het `index.css`-bestand uit de `dist` map van het
-pakket, en omring het deel van je applicatie waar je het thema wilt toepassen met de Rijkshuisstijl-thema: `rhc-theme`.
-
-```tsx
 import '@rijkshuisstijl-community/design-tokens/dist/index.css'; // design tokens importeren
 import '@rijkshuisstijl-community/components-css/dist/index.css'; // css importeren
+import { Button } from '@rijkshuisstijl-community/components-react';
 
 function App() {
   return (
     <div className="rhc-theme">
+      {/* geef alle thema tokens mee an child components */}
       <Button>Click Here!</Button>
     </div>
   );
 }
 ```
+
+> [!WARNING]  
+> Sommige componenten gebruiken de [useRef](https://react.dev/reference/react/useRef) hook, die alleen werkt in Client
+> Componenten. Voeg `"use client"` toe bovenaan het bestand om dit op te lossen. lees [hier](https://react.dev/reference/rsc/server-components) meer over server en client components in react.
+
+### Thema toepassen
+
+Voor de themas maken we gebruik van de volgende 2 packages: [design-tokens npm package](https://www.npmjs.com/package/@rijkshuisstijl-community/design-tokens) en [component css npm package](https://www.npmjs.com/package/@rijkshuisstijl-community/components-css)
+
+Dit pakket bevat de CSS-variabelen van het design systeem. Importeer het `index.css`-bestand uit de `dist` map van het
+pakket, en omring het deel van je applicatie waar je het thema wilt toepassen met de Rijkshuisstijl-thema: `rhc-theme`.
 
 Bekijk de [packages/font/README.md](https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/font/README.md) voor de meerdere manieren om de lettertypen te installeren voor jouw project.


### PR DESCRIPTION
Omdat ik zelf 2x heb geprobeerd en gefaald om deze componenten te gebruiken dacht ik dat het handig zou zijn om een poging te wagen om de README te herzien. 

Ik heb hier vooral gefocused om de eerste code snippet dat je ziet meteen de componenten en styling toepast in je app en de toelichting over de styling packages daar dan onder te hebben. 

![image](https://github.com/user-attachments/assets/112f33ec-bd94-4bca-b272-6d7d4dada30a)
