### PR TITLE
fix: design token type borderStyle does not exist

### DIFF
--- a/.changeset/cold-baboons-push.md
+++ b/.changeset/cold-baboons-push.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/design-tokens': patch
+---
+
+Vervang niet bestaand Design Token type "borderStyle" met "other".

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -3532,7 +3532,7 @@
           },
           "border-block-end-style": {
             "value": "solid",
-            "type": "borderStyle"
+            "type": "other"
           },
           "color": {
             "value": "{rhc.color.foreground.default}",
@@ -3886,7 +3886,7 @@
       "file": {
         "border-style": {
           "value": "solid",
-          "type": "borderStyle"
+          "type": "other"
         },
         "border-color": {
           "value": "{rhc.color.primary.500}",
@@ -4010,7 +4010,7 @@
         },
         "border-block-start-style": {
           "value": "solid",
-          "type": "borderStyle"
+          "type": "other"
         },
         "outlined": {
           "background-color": {
@@ -6527,7 +6527,7 @@
             },
             "border-style": {
               "value": "solid",
-              "type": "borderStyle"
+              "type": "other"
             },
             "border-color": {
               "value": "{rhc.color.primary.500}",
@@ -6639,7 +6639,7 @@
           },
           "border-style": {
             "value": "solid",
-            "type": "borderStyle"
+            "type": "other"
           },
           "border-width": {
             "value": "{rhc.border-width.m}",
@@ -6763,7 +6763,7 @@
           },
           "border-style": {
             "value": "{nl.skip-link.focus.border-style}",
-            "type": "borderStyle"
+            "type": "other"
           },
           "border-width": {
             "value": "{nl.skip-link.focus.border-width}",


### PR DESCRIPTION
Design Token type "borderStyle" does not exist, as told by Rozerin, so we change it to the suggested "other".