### PR TITLE
fix: add react peer dep te components-twig

### DIFF
--- a/.changeset/little-stars-pick.md
+++ b/.changeset/little-stars-pick.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/components-twig': patch
+---
+
+Voeg `react` als peer dependency toe aan `components-twig` om Storybook builds succesvol te laten verlopen in Chromatic.

--- a/packages/components-twig/package.json
+++ b/packages/components-twig/package.json
@@ -42,5 +42,9 @@
     "rimraf": "6.0.1",
     "twig": "1.17.1",
     "typescript": "5.8.3"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-dom": "*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,10 +164,6 @@ importers:
         specifier: 5.7.3
         version: 5.7.3
 
-  apps/rhc-templates/dist: {}
-
-  apps/rhc-templates/dist/types: {}
-
   packages/components-angular:
     dependencies:
       '@angular-devkit/build-angular':
@@ -428,6 +424,12 @@ importers:
       '@rijkshuisstijl-community/components-css':
         specifier: workspace:*
         version: link:../components-css
+      react:
+        specifier: '*'
+        version: 19.1.0
+      react-dom:
+        specifier: '*'
+        version: 19.1.0(react@19.1.0)
     devDependencies:
       '@nl-design-system/tsconfig':
         specifier: 1.0.3


### PR DESCRIPTION
Fix: Voeg `react` als peer dependency toe aan `components-twig` om Storybook builds succesvol te laten verlopen in Chromatic.

Tijdens het builden van Storybook via Chromatic kwam een fout voor omdat `react` ontbrak als peer dependency in het `components-twig` package. Hoewel `react` upstream beschikbaar is, verwacht het buildproces dat deze expliciet gedeclareerd is in de dependency chain. Door `react` als peer dependency toe te voegen, wordt de module-resolutie correct afgehandeld, waardoor de build weer slaagt.