### PR TITLE
fix: consider new icon exports in icon stories (#1695)

### DIFF
--- a/packages/storybook/src/community/icon.stories.tsx
+++ b/packages/storybook/src/community/icon.stories.tsx
@@ -1,7 +1,8 @@
 import {
+  defaultIconSet,
+  flagIconSet,
   getIconSet,
   Icon,
-  defaultIconSet as iconSet,
   registerIconSet,
 } from '@rijkshuisstijl-community/components-react';
 import { Meta, StoryObj } from '@storybook/react';
@@ -9,7 +10,8 @@ import { IconBrandX } from '@tabler/icons-react';
 import readme from './icon.md?raw';
 import { mergeMarkdown } from '../../helpers/merge-markdown';
 
-registerIconSet(iconSet);
+registerIconSet(defaultIconSet);
+registerIconSet(flagIconSet);
 
 const meta = {
   title: 'Rijkshuisstijl/Icon',

--- a/packages/storybook/src/web-components/icon.stories.tsx
+++ b/packages/storybook/src/web-components/icon.stories.tsx
@@ -1,11 +1,13 @@
-import { getIconSet, defaultIconSet as iconSet, registerIconSet } from '@rijkshuisstijl-community/components-react';
+import { defaultIconSet, flagIconSet, getIconSet, registerIconSet } from '@rijkshuisstijl-community/components-react';
 import { IconWebComponent } from '@rijkshuisstijl-community/web-components';
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { IconBrandX } from '@tabler/icons-react';
 import { mergeMarkdown } from '../../helpers/merge-markdown';
 import readme from '../community/icon.md?raw';
 
-registerIconSet(iconSet);
+registerIconSet(defaultIconSet);
+registerIconSet(flagIconSet);
+
 IconWebComponent.define();
 
 const meta = {


### PR DESCRIPTION
I noticed it in chromatic too late and i had automerge on in https://github.com/nl-design-system/rijkshuisstijl-community/pull/1700