### PR TITLE
feat: alert text colors

### DIFF
--- a/.changeset/blue-stars-flash.md
+++ b/.changeset/blue-stars-flash.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/components-css': major
+---
+
+Alert text color now follows design

--- a/packages/components-css/src/alert/index.scss
+++ b/packages/components-css/src/alert/index.scss
@@ -9,8 +9,14 @@
   --nl-heading-level-3-line-height: var(--utrecht-alert-heading-line-height);
   --nl-heading-level-4-line-height: var(--utrecht-alert-heading-line-height);
   --nl-heading-level-5-line-height: var(--utrecht-alert-heading-line-height);
+  --nl-heading-level-1-color: var(--utrecht-alert-color);
+  --nl-heading-level-2-color: var(--utrecht-alert-color);
+  --nl-heading-level-3-color: var(--utrecht-alert-color);
+  --nl-heading-level-4-color: var(--utrecht-alert-color);
+  --nl-heading-level-5-color: var(--utrecht-alert-color);
   --utrecht-icon-inset-block-start: var(--utrecht-alert-icon-inset-block-start);
   --nl-paragraph-line-height: var(--utrecht-alert-message-line-height);
+  --nl-paragraph-color: var(--utrecht-alert-color);
 }
 
 .utrecht-alert__message {

--- a/packages/storybook/src/community/alert.stories.tsx
+++ b/packages/storybook/src/community/alert.stories.tsx
@@ -19,7 +19,7 @@ const meta = {
       },
     },
     heading: {
-      description: 'Alert heading - used in default webcomponent slot',
+      description: 'Alert heading',
       type: {
         name: 'string',
       },
@@ -36,7 +36,7 @@ const meta = {
       },
     },
     textContent: {
-      description: 'Alert content - used in default webcomponent slot',
+      description: 'Alert content',
       type: {
         name: 'string',
       },

--- a/packages/storybook/src/community/alert.stories.tsx
+++ b/packages/storybook/src/community/alert.stories.tsx
@@ -1,8 +1,8 @@
 /* @license CC0-1.0 */
 
-import { Alert } from '@rijkshuisstijl-community/components-react';
 import type { Meta, StoryObj } from '@storybook/react';
 import readme from './alert.md?raw';
+import { Alert } from '../../../components-react';
 import { mergeMarkdown } from '../../helpers/merge-markdown';
 
 const meta = {


### PR DESCRIPTION
De tekstkleur van heading en paragraaf binnen Alert component laten luisteren naar `--utrecht-alert-color` zoals bedoeld.

Fixes https://github.com/nl-design-system/rijkshuisstijl-community/issues/1692