### PR TITLE
chore: remove unused deprecated button token

### DIFF
--- a/.changeset/fuzzy-turkeys-ring.md
+++ b/.changeset/fuzzy-turkeys-ring.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/design-tokens': patch
+---
+
+Removed unused tokens.

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -2453,7 +2453,7 @@
       }
     }
   },
-  "components/button/base": {
+  "components/button": {
     "utrecht": {
       "button": {
         "background-color": {
@@ -2958,18 +2958,6 @@
           "type": "dimension",
           "value": "{rhc.space.0}",
           "description": "[code-only]"
-        }
-      }
-    }
-  },
-  "components/button/deprecated": {
-    "utrecht": {
-      "button": {
-        "icon": {
-          "gap": {
-            "value": "{utrecht.button.column-gap}",
-            "type": "dimension"
-          }
         }
       }
     }


### PR DESCRIPTION
https://github.com/nl-design-system/rijkshuisstijl-community/issues/1774 Cleanup based on converting to new figma library