### PR TITLE
feat: remove fixed width from component to delegate sizing to layout

### DIFF
--- a/.changeset/floppy-nights-do.md
+++ b/.changeset/floppy-nights-do.md
@@ -1,0 +1,6 @@
+---
+'@rijkshuisstijl-community/design-tokens': patch
+'@rijkshuisstijl-community/components-css': patch
+---
+
+Remove fixed width from Card As Link component to delegate sizing to layout

--- a/packages/components-css/src/card-as-link/_mixin.scss
+++ b/packages/components-css/src/card-as-link/_mixin.scss
@@ -7,7 +7,7 @@
   flex-direction: column;
   font-family: var(--rhc-font-family-primary, inherit);
   font-size: var(--rhc-font-size-xs-desktop, inherit);
-  inline-size: var(--rhc-card-as-link-inline-size, 328px);
+  inline-size: 100%;
   line-height: var(--rhc-line-height-md, inherit);
   position: relative;
   text-decoration: none;
@@ -112,7 +112,7 @@
 
   block-size: 100%;
   filter: brightness(var(--rhc-card-as-link-full-bleed-opacity, 0.5));
-  inline-size: var(--rhc-card-as-link-inline-size, 328px);
+  inline-size: 100%;
   position: absolute;
   z-index: -1;
 }

--- a/packages/components-css/src/card-as-link/_mixin.scss
+++ b/packages/components-css/src/card-as-link/_mixin.scss
@@ -74,6 +74,7 @@
 
 @mixin rhc-card-as-link__content {
   display: flex;
+  flex: 1;
   flex-direction: column;
   padding-block-end: var(--rhc-card-as-link-padding-block-end, 16px);
   padding-block-start: var(--rhc-card-as-link-padding-block-start, 16px);

--- a/packages/components-css/src/card-as-link/_mixin.scss
+++ b/packages/components-css/src/card-as-link/_mixin.scss
@@ -73,14 +73,13 @@
 }
 
 @mixin rhc-card-as-link__content {
-  display: flex;
+  @include container-content;
+
   flex: 1;
-  flex-direction: column;
-  padding-block-end: var(--rhc-card-as-link-padding-block-end, 16px);
-  padding-block-start: var(--rhc-card-as-link-padding-block-start, 16px);
-  padding-inline-end: var(--rhc-card-as-link-padding-inline-end, 16px);
-  padding-inline-start: var(--rhc-card-as-link-padding-inline-start, 16px);
-  row-gap: var(--rhc-card-as-link-row-gap, 12px);
+}
+
+@mixin rhc-card-as-link__footer {
+  @include container-content;
 }
 
 @mixin rhc-card-as-link--horizontal__content {
@@ -182,6 +181,16 @@
 
 @mixin rhc-card-as-link__metadata {
   color: var(--rhc-card-as-link-metadata-color, #154273);
+}
+
+@mixin container-content {
+  display: flex;
+  flex-direction: column;
+  padding-block-end: var(--rhc-card-as-link-padding-block-end, 16px);
+  padding-block-start: var(--rhc-card-as-link-padding-block-start, 16px);
+  padding-inline-end: var(--rhc-card-as-link-padding-inline-end, 16px);
+  padding-inline-start: var(--rhc-card-as-link-padding-inline-start, 16px);
+  row-gap: var(--rhc-card-as-link-row-gap, 12px);
 }
 
 @mixin rounded-border-corners {

--- a/packages/components-css/src/card-as-link/index.scss
+++ b/packages/components-css/src/card-as-link/index.scss
@@ -29,7 +29,7 @@
 }
 
 .rhc-card-as-link__footer {
-  @include mixin.rhc-card-as-link__content;
+  @include mixin.rhc-card-as-link__footer;
 }
 
 .rhc-card-as-link__image-container {

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -2989,10 +2989,6 @@
           "value": "{rhc.space.200}",
           "type": "spacing"
         },
-        "inline-size": {
-          "value": "100%",
-          "type": "sizing"
-        },
         "icon": {
           "color": {
             "value": "{rhc.color.primary.500}",

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -2990,7 +2990,7 @@
           "type": "spacing"
         },
         "inline-size": {
-          "value": "328px",
+          "value": "100%",
           "type": "sizing"
         },
         "icon": {


### PR DESCRIPTION
De content neemt nu de maximale beschikbare hoogte in, zodat de CTA hyperlinks naar beneden uitgelijnd zijn.

Zie hier voorbeeld zonder wijziging:
<img width="926" height="317" alt="image" src="https://github.com/user-attachments/assets/f87e0999-0ad0-43ba-b588-34ac0cbcbdcd" />

En dit is met de wijzigingen (inline-size 100% + maximale hoogte card content):
<img width="983" height="310" alt="image" src="https://github.com/user-attachments/assets/d4012709-6b38-406f-aff4-fce7fe5b7258" />
