### PR TITLE
feat: nav bar bottom border added as designed

### DIFF
--- a/.changeset/khaki-areas-smell.md
+++ b/.changeset/khaki-areas-smell.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/components-css': patch
+---
+
+Added bottom border for nav bar

--- a/packages/components-css/src/navbar/index.scss
+++ b/packages/components-css/src/navbar/index.scss
@@ -1,6 +1,9 @@
 .rhc-nav-bar__container {
   align-items: center;
   background-color: var(--rhc-nav-bar-background-color);
+  border-block-end-color: var(--rhc-nav-bar-border-color);
+  border-block-end-style: solid;
+  border-block-end-width: var(--rhc-nav-bar-border-block-end-width);
   display: flex;
   inline-size: var(--rhc-nav-bar-container-inline-size);
   justify-content: center;
@@ -9,7 +12,6 @@
 .rhc-nav-bar {
   align-items: center;
   background-color: var(--rhc-nav-bar-background-color);
-  border-block-end-width: var(--rhc-nav-bar-border-block-end-width);
   color: var(--rhc-nav-bar-color);
   column-gap: var(--rhc-nav-bar-content-column-gap);
   display: flex;


### PR DESCRIPTION
Volgens het ontwerp in Figma zou de nav bar component een border bottom moeten hebben:
<img width="2369" height="675" alt="image" src="https://github.com/user-attachments/assets/28611e24-806e-430f-a4fc-00ef9ada1244" />

Dit is nu geïmplementeerd ook in de code, zie voorbeeld:
<img width="2059" height="698" alt="image" src="https://github.com/user-attachments/assets/5778d64f-0c38-4553-bb3e-467f433c800f" />
