### PR TITLE
1752 voeg verschillende themas toe aan de visual regression tests

### DIFF
--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -31,6 +31,7 @@
     "@chromatic-com/storybook": "3.2.6",
     "@etchteam/storybook-addon-status": "5.0.0",
     "@nl-rvo/assets": "1.0.0-alpha.360",
+    "@nl-design-system-unstable/theme-toolkit": "1.0.0",
     "@playwright/test": "1.52.0",
     "@rijkshuisstijl-community/assets": "workspace:*",
     "@rijkshuisstijl-community/components-css": "workspace:*",

--- a/packages/storybook/src/community/button-visual/States.tsx
+++ b/packages/storybook/src/community/button-visual/States.tsx
@@ -1,0 +1,44 @@
+import { Button } from '@rijkshuisstijl-community/components-react';
+import { Fragment } from 'react';
+
+const appearances = ['primary-action', 'secondary-action', 'subtle'];
+
+export const InteractiveStates = () => (
+  <>
+    {appearances.map((appearance) => (
+      <Fragment key={appearance}>
+        <Button appearance={`${appearance}-button`} className="utrecht-button--active" key={`active-${appearance}`}>
+          Active Button ({appearance})
+        </Button>
+        <Button
+          appearance={`${appearance}-button`}
+          className="utrecht-button--focus utrecht-button--focus-visible"
+          key={`focus-${appearance}`}
+        >
+          Focus Button ({appearance})
+        </Button>
+        <Button appearance={`${appearance}-button`} className="utrecht-button--hover" key={`hover-${appearance}`}>
+          Hover Button ({appearance})
+        </Button>
+      </Fragment>
+    ))}
+  </>
+);
+
+export const PropertyStates = () => (
+  <>
+    {appearances.map((appearance) => (
+      <Fragment key={appearance}>
+        <Button disabled appearance={`${appearance}-button`} key={`disabled-${appearance}`}>
+          Disabled Button ({appearance})
+        </Button>
+        <Button busy appearance={`${appearance}-button`} key={`busy-${appearance}`}>
+          Busy Button ({appearance})
+        </Button>
+        <Button pressed appearance={`${appearance}-button`} key={`pressed-${appearance}`}>
+          Pressed Button ({appearance})
+        </Button>
+      </Fragment>
+    ))}
+  </>
+);

--- a/packages/storybook/src/community/button-visual/Variants.tsx
+++ b/packages/storybook/src/community/button-visual/Variants.tsx
@@ -1,0 +1,11 @@
+import { Button } from '@rijkshuisstijl-community/components-react';
+
+export const Appearances = () => (
+  <>
+    <Button appearance="primary-action-button">Primary Action Button</Button>
+    <Button appearance="secondary-action-button">Secondary Action Button</Button>
+    <Button appearance="subtle-button">Subtle Button</Button>
+  </>
+);
+
+export const Sizes = () => <Button>Small Button</Button>;

--- a/packages/storybook/src/community/button-visual/index.ts
+++ b/packages/storybook/src/community/button-visual/index.ts
@@ -1,0 +1,2 @@
+export * from './States';
+export * from './Variants';

--- a/packages/storybook/src/community/button.stories.tsx
+++ b/packages/storybook/src/community/button.stories.tsx
@@ -1,6 +1,6 @@
 /* @license CC0-1.0 */
 
-import { IconButton } from '@rijkshuisstijl-community/components-react';
+import { Heading, IconButton } from '@rijkshuisstijl-community/components-react';
 import { Button, Icon } from '@rijkshuisstijl-community/components-react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { IconArrowRight, IconCalendarEvent } from '@tabler/icons-react';
@@ -176,43 +176,69 @@ export const IconOnly: StoryObj<typeof IconButton> = {
 export const DesignTokens = createDesignTokensStory(meta);
 export const Visual = createVisualRegressionStory(() => (
   <>
-    <h4 className="utrecht-heading-3">Uitvoerend</h4>
-    <h5 className="utrecht-heading-4">paars</h5>
+    <Heading appearanceLevel={2} level={1}>
+      Button
+    </Heading>
+    <Heading appearanceLevel={3} level={2}>
+      KOOP
+    </Heading>
+    <VisualRegressionWrapper className={`koop`}>
+      <Appearances />
+      <Sizes />
+      <InteractiveStates />
+      <PropertyStates />
+    </VisualRegressionWrapper>
+    <Heading appearanceLevel={3} level={2}>
+      Uitvoerend
+    </Heading>
+    <Heading appearanceLevel={4} level={3}>
+      Paars
+    </Heading>
     <VisualRegressionWrapper className={`uitvoerend-paars`}>
       <Appearances />
       <Sizes />
       <InteractiveStates />
       <PropertyStates />
     </VisualRegressionWrapper>
-    <h5 className="utrecht-heading-4">hemelblauw</h5>
+    <Heading appearanceLevel={4} level={3}>
+      Hemelblauw
+    </Heading>
     <VisualRegressionWrapper className={`uitvoerend-hemelblauw`}>
       <Appearances />
       <Sizes />
       <InteractiveStates />
       <PropertyStates />
     </VisualRegressionWrapper>
-    <h5 className="utrecht-heading-4">groen</h5>
+    <Heading appearanceLevel={4} level={3}>
+      Groen
+    </Heading>
     <VisualRegressionWrapper className={`uitvoerend-groen`}>
       <Appearances />
       <Sizes />
       <InteractiveStates />
       <PropertyStates />
     </VisualRegressionWrapper>
-    <h5 className="utrecht-heading-4">oranje</h5>
+    <Heading appearanceLevel={4} level={3}>
+      Oranje
+    </Heading>
     <VisualRegressionWrapper className={`uitvoerend-oranje`}>
       <Appearances />
       <Sizes />
       <InteractiveStates />
       <PropertyStates />
     </VisualRegressionWrapper>
-    <h5 className="utrecht-heading-4">violet</h5>
+    <Heading appearanceLevel={4} level={3}>
+      Violet
+    </Heading>
     <VisualRegressionWrapper className={`uitvoerend-violet`}>
       <Appearances />
       <Sizes />
       <InteractiveStates />
       <PropertyStates />
     </VisualRegressionWrapper>
-    <h5 className="utrecht-heading-4">mintgroen</h5>
+    <Heading appearanceLevel={4} level={3}>
+      Mintgroen
+    </Heading>
     <VisualRegressionWrapper className={`uitvoerend-mintgroen`}>
       <Appearances />
       <Sizes />

--- a/packages/storybook/src/community/button.stories.tsx
+++ b/packages/storybook/src/community/button.stories.tsx
@@ -12,6 +12,9 @@ import wcagDocs from '@utrecht/components/button/docs/wcag.nl.md?raw';
 import { PropsWithChildren } from 'react';
 import rhcReadme from './button.md?raw';
 import { mergeMarkdown } from '../../helpers/merge-markdown';
+import { createDesignTokensStory, createVisualRegressionStory, VisualRegressionWrapper } from '../utils';
+import { InteractiveStates, PropertyStates } from './button-visual/States';
+import { Appearances, Sizes } from './button-visual/Variants';
 
 interface ButtonStoryProps {
   appearance: string;
@@ -169,3 +172,52 @@ export const IconOnly: StoryObj<typeof IconButton> = {
     </IconButton>
   ),
 };
+
+export const DesignTokens = createDesignTokensStory(meta);
+export const Visual = createVisualRegressionStory(() => (
+  <>
+    <h4 className="utrecht-heading-3">Uitvoerend</h4>
+    <h5 className="utrecht-heading-4">paars</h5>
+    <VisualRegressionWrapper className={`uitvoerend-paars`}>
+      <Appearances />
+      <Sizes />
+      <InteractiveStates />
+      <PropertyStates />
+    </VisualRegressionWrapper>
+    <h5 className="utrecht-heading-4">hemelblauw</h5>
+    <VisualRegressionWrapper className={`uitvoerend-hemelblauw`}>
+      <Appearances />
+      <Sizes />
+      <InteractiveStates />
+      <PropertyStates />
+    </VisualRegressionWrapper>
+    <h5 className="utrecht-heading-4">groen</h5>
+    <VisualRegressionWrapper className={`uitvoerend-groen`}>
+      <Appearances />
+      <Sizes />
+      <InteractiveStates />
+      <PropertyStates />
+    </VisualRegressionWrapper>
+    <h5 className="utrecht-heading-4">oranje</h5>
+    <VisualRegressionWrapper className={`uitvoerend-oranje`}>
+      <Appearances />
+      <Sizes />
+      <InteractiveStates />
+      <PropertyStates />
+    </VisualRegressionWrapper>
+    <h5 className="utrecht-heading-4">violet</h5>
+    <VisualRegressionWrapper className={`uitvoerend-violet`}>
+      <Appearances />
+      <Sizes />
+      <InteractiveStates />
+      <PropertyStates />
+    </VisualRegressionWrapper>
+    <h5 className="utrecht-heading-4">mintgroen</h5>
+    <VisualRegressionWrapper className={`uitvoerend-mintgroen`}>
+      <Appearances />
+      <Sizes />
+      <InteractiveStates />
+      <PropertyStates />
+    </VisualRegressionWrapper>
+  </>
+));

--- a/packages/storybook/src/community/link-visual/States.tsx
+++ b/packages/storybook/src/community/link-visual/States.tsx
@@ -1,0 +1,19 @@
+import { Link } from '@rijkshuisstijl-community/components-react';
+
+export const VisualStates = () => (
+  <>
+    <Link href="#">Link</Link>
+    <Link className="nl-link--hover" href="#">
+      Hover link
+    </Link>
+    <Link className="nl-link--active" href="#">
+      Active link
+    </Link>
+    <Link className="nl-link--focus nl-link--focus-visible" href="#">
+      Focus link
+    </Link>
+    <Link className="nl-link--focus-visited" href="#">
+      Visited link
+    </Link>
+  </>
+);

--- a/packages/storybook/src/community/link.stories.tsx
+++ b/packages/storybook/src/community/link.stories.tsx
@@ -1,6 +1,6 @@
 /* @license CC0-1.0 */
 
-import { Icon, Link, Paragraph } from '@rijkshuisstijl-community/components-react';
+import { Heading, Icon, Link, Paragraph } from '@rijkshuisstijl-community/components-react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { IconCalendarEvent } from '@tabler/icons-react';
 import readme from '@utrecht/components/link/README.md?raw';
@@ -21,6 +21,8 @@ import usageDocs from '@utrecht/components/link/docs/usage.nl.md?raw';
 import visualDesignDocs from '@utrecht/components/link/docs/visual-design.nl.md?raw';
 import wcagDocs from '@utrecht/components/link/docs/wcag.nl.md?raw';
 import { mergeMarkdown } from '../../helpers/merge-markdown';
+import { createDesignTokensStory, createVisualRegressionStory, VisualRegressionWrapper } from '../utils';
+import { VisualStates } from './link-visual/States';
 
 const meta = {
   title: 'Rijkshuisstijl/Link',
@@ -209,3 +211,58 @@ export const LinkInParagraph: Story = {
     );
   },
 };
+
+export const DesignTokens = createDesignTokensStory(meta);
+
+export const Visual = createVisualRegressionStory(() => (
+  <>
+    <Heading appearanceLevel={2} level={1}>
+      Link
+    </Heading>
+    <Heading appearanceLevel={3} level={2}>
+      KOOP
+    </Heading>
+    <VisualRegressionWrapper className={`koop`}>
+      <VisualStates />
+    </VisualRegressionWrapper>
+    <Heading appearanceLevel={3} level={2}>
+      Uitvoerend
+    </Heading>
+    <Heading appearanceLevel={4} level={3}>
+      Paars
+    </Heading>
+    <VisualRegressionWrapper className={`uitvoerend-paars`}>
+      <VisualStates />
+    </VisualRegressionWrapper>
+    <Heading appearanceLevel={4} level={3}>
+      Hemelblauw
+    </Heading>
+    <VisualRegressionWrapper className={`uitvoerend-hemelblauw`}>
+      <VisualStates />
+    </VisualRegressionWrapper>
+    <Heading appearanceLevel={4} level={3}>
+      Groen
+    </Heading>
+    <VisualRegressionWrapper className={`uitvoerend-groen`}>
+      <VisualStates />
+    </VisualRegressionWrapper>
+    <Heading appearanceLevel={4} level={3}>
+      Oranje
+    </Heading>
+    <VisualRegressionWrapper className={`uitvoerend-oranje`}>
+      <VisualStates />
+    </VisualRegressionWrapper>
+    <Heading appearanceLevel={4} level={3}>
+      Violet
+    </Heading>
+    <VisualRegressionWrapper className={`uitvoerend-violet`}>
+      <VisualStates />
+    </VisualRegressionWrapper>
+    <Heading appearanceLevel={4} level={3}>
+      Mintgroen
+    </Heading>
+    <VisualRegressionWrapper className={`uitvoerend-mintgroen`}>
+      <VisualStates />
+    </VisualRegressionWrapper>
+  </>
+));

--- a/packages/storybook/src/utils/createDesignTokensStory.tsx
+++ b/packages/storybook/src/utils/createDesignTokensStory.tsx
@@ -1,0 +1,46 @@
+// @ts-expect-error no definition file
+import { ComponentTokensSection } from '@nl-design-system-unstable/theme-toolkit';
+import type { StoryObj } from '@storybook/react';
+
+type DesignToken = {
+  comment?: string;
+  name?: string;
+  path?: string;
+  value: string | number;
+};
+
+type Props = {
+  component: string;
+  definition: DesignTokenTree;
+  tokens: string | number;
+};
+
+interface DesignTokenTree {
+  [index: string]: DesignToken | DesignTokenTree;
+}
+
+export const createDesignTokensStory = (meta: any): StoryObj => {
+  const designTokenStory: StoryObj<Props> = {
+    args: {
+      tokens: meta.parameters.tokens,
+      definition: meta.parameters.tokensDefinition,
+      component: meta.parameters.tokensPrefix,
+    },
+    parameters: {
+      chromatic: {
+        disableSnapShot: true,
+      },
+      docs: {
+        source: {
+          code: '',
+        },
+      },
+      withDocument: true,
+    },
+    render: (({ tokens, definition, component }: Props) => {
+      return <ComponentTokensSection component={component} definition={definition} tokens={tokens} />;
+    }) as any,
+  };
+
+  return designTokenStory;
+};

--- a/packages/storybook/src/utils/createDesignTokensStory.tsx
+++ b/packages/storybook/src/utils/createDesignTokensStory.tsx
@@ -1,4 +1,6 @@
 // @ts-expect-error no definition file
+// This file includes code from nl-design-system/lux
+// Licensed under the EUPL v1.2
 import { ComponentTokensSection } from '@nl-design-system-unstable/theme-toolkit';
 import type { StoryObj } from '@storybook/react';
 

--- a/packages/storybook/src/utils/createVisualRegressionStory.tsx
+++ b/packages/storybook/src/utils/createVisualRegressionStory.tsx
@@ -1,3 +1,5 @@
+// This file includes code from nl-design-system/lux
+// Licensed under the EUPL v1.2
 import { StoryObj } from '@storybook/react';
 import React from 'react';
 import { PropsWithChildren, ReactElement } from 'react';

--- a/packages/storybook/src/utils/createVisualRegressionStory.tsx
+++ b/packages/storybook/src/utils/createVisualRegressionStory.tsx
@@ -1,0 +1,87 @@
+import { StoryObj } from '@storybook/react';
+import React from 'react';
+import { PropsWithChildren, ReactElement } from 'react';
+
+type VisualRegressionRenderFn = () => ReactElement<void, any>;
+interface CreateVisualRegressionStoryFn {
+  /* eslint-disable no-unused-vars */
+  (
+    render: VisualRegressionRenderFn,
+    options?: {
+      withDocument?: boolean;
+    },
+  ): StoryObj;
+  /* eslint-enable */
+}
+
+/**
+ * Create a story which will be used by Chromatic, but is invisible to the user. You can still navigate to it via URL.
+ *
+ * **Usage**
+ *
+ * Combine it with {@link VisualRegressionWrapper} component to make sure all visual regression stories have the same layout
+ *
+ * ```ts
+ * export const Visual = createVisualRegressionStory(() => (
+ *   <VisualRegressionWrapper>
+ *     <MyComponent state="default" />
+ *     <MyComponent state="special" />
+ *     <MyComponent state="special2" />
+ *     <MyComponent state="special3" />
+ *   </VisualRegressionWrapper>
+ * ));
+ * ```
+ *
+ * @remarks By starting your story's name with "visual" it is still tested by Chromatic, but not visible in the side bar. You can still navigate to it through the URL.
+ *
+ * @see {@link VisualRegressionWrapper}
+ * @param render function which renders the story's body
+ * @param options set options for the story
+ * @returns a storybook story
+ */
+export const createVisualRegressionStory: CreateVisualRegressionStoryFn = (
+  render: VisualRegressionRenderFn,
+  options = {},
+): StoryObj => {
+  const { withDocument = false } = options;
+  return {
+    parameters: {
+      options: {
+        showPanel: false,
+      },
+      a11y: { disable: true },
+      interactions: { disable: true },
+      actions: { disable: true },
+      controls: { disable: true },
+      backgrounds: { default: 'transparent' },
+      chromatic: {
+        disable: false,
+        disableSnapshot: false,
+      },
+      withDocument,
+    },
+    render,
+  };
+};
+
+/**
+ * Create an HTML flex container so every visual regression story has the same layout
+ *
+ * Use together with #createVisualRegressionStory
+ *
+ * @see {@link createVisualRegressionStory} on how to use it
+ * @param props {@link React.PropsWithChildren}
+ * @returns A {@link React.ReactElement}
+ */
+export const VisualRegressionWrapper = ({
+  children,
+  className,
+}: PropsWithChildren<{ className: string }>): React.ReactElement => {
+  return (
+    <div
+      className={`lsb-visual-regression-wrapper ${className.includes('dark') ? 'lsb-visual-regression-wrapper--dark' : ''} ${className}`}
+    >
+      {children}
+    </div>
+  );
+};

--- a/packages/storybook/src/utils/index.ts
+++ b/packages/storybook/src/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './createDesignTokensStory';
+export * from './createVisualRegressionStory';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -480,6 +480,9 @@ importers:
       '@etchteam/storybook-addon-status':
         specifier: 5.0.0
         version: 5.0.0
+      '@nl-design-system-unstable/theme-toolkit':
+        specifier: 1.0.0
+        version: 1.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.12(prettier@3.5.3))
       '@nl-rvo/assets':
         specifier: 1.0.0-alpha.360
         version: 1.0.0-alpha.360
@@ -2270,6 +2273,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/runtime@7.24.7':
+    resolution: {integrity: sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/runtime@7.26.10':
     resolution: {integrity: sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==}
     engines: {node: '>=6.9.0'}
@@ -2659,6 +2666,37 @@ packages:
 
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
+
+  '@gemeente-denhaag/button@0.2.3-alpha.398':
+    resolution: {integrity: sha512-cCG5UQhCxnbykAn8Jo1s3CsRWPRMiGNn9O9f4fj5GRK1GJrV6XKqFdKY/piM87NBA4THghz5OoSem1EF6fsgJw==}
+    peerDependencies:
+      react: ^18.0.0
+
+  '@gemeente-denhaag/design-tokens-common@0.2.3-alpha.400':
+    resolution: {integrity: sha512-ptmBqqn2NeerkyGFnp+QSgE7gkY1oIN4tiiRjTG6kwgcNQ/WakB9N+p49W/a2rcF+Fz0XsqWAd5CzBCFH+aZIA==}
+
+  '@gemeente-denhaag/design-tokens-components@0.2.3-alpha.400':
+    resolution: {integrity: sha512-YtrtyDxhyszyBakn2q+PA+40l63JcxA0laNo7//hy8yWUWmk3w05l8eOynjryJU/0tyGCgA3GgxIuVW5NCWaEQ==}
+
+  '@gemeente-denhaag/icons@0.2.3-alpha.398':
+    resolution: {integrity: sha512-NDU9GXKNlwwRBBAyYSqJhjLgX2CG28N15GRdQHR+LbU+z0av6YOE5RBQK6kCNaEXFZX1ah01DY6+4TcGgwDxXg==}
+    peerDependencies:
+      react: ^18.0.0
+
+  '@gemeente-denhaag/process-steps@0.1.0-alpha.227':
+    resolution: {integrity: sha512-zBcjU/zTrhT+Oquw3EZIPUo6nM3JQKQhXGk25ZSYC6B5i7rZrhMqeoMnIXIFQzMeeU4fBWlJuYlfJ27Y/DU2jQ==}
+    peerDependencies:
+      react: ^18.0.0
+
+  '@gemeente-denhaag/step-marker@0.0.1-alpha.99':
+    resolution: {integrity: sha512-TQXbieNdpAbFI3sKjHdRJqFXNdhQIzzuhvJEFbcbjNfFi97IdklTs2bHntLIEYuUVRBzvqiEPyqkU9a3zTcoLw==}
+    peerDependencies:
+      react: ^18.0.0
+
+  '@gemeente-denhaag/typography@0.2.3-alpha.398':
+    resolution: {integrity: sha512-LN0HNjXOzZbpv5KJHWf305h+nAtCBqlSM33C+Tuv3y04+xJ+ZWYFz4uul9TMLI35DYnd03sZV9YHtWV1vyOS8w==}
+    peerDependencies:
+      react: ^18.0.0
 
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -3612,6 +3650,11 @@ packages:
       '@babel/runtime': ^7
       react: ^18
 
+  '@nl-design-system-unstable/theme-toolkit@1.0.0':
+    resolution: {integrity: sha512-RzyneDefAIMgJ7zsR/EkZ6Gpx6sbTLKrgmt427ZTNksqfe6rxp7USDOXo8zKWHhpF/HZTwH1OUs2oEHpXq51dw==}
+    peerDependencies:
+      react: ^18
+
   '@nl-design-system/tsconfig@1.0.3':
     resolution: {integrity: sha512-Ejt9+yETgYXjE3O5WQEeiVOVE/BFU2MSgS0WIIq+kgiaBWduN0f+ze5F+s2VzvFNYimMAWwaYE4a+cqrphcm8Q==}
     peerDependencies:
@@ -4461,6 +4504,18 @@ packages:
       zone.js:
         optional: true
 
+  '@storybook/blocks@8.2.1':
+    resolution: {integrity: sha512-7E5WAx5JcrPBCjonogfTvcLJ1y6IFQzqLv1mone8TH1b5lCHuLtWMxYY/4oQabfEanVUpo81KfbyooiR3FXlOA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      storybook: ^8.2.1
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   '@storybook/blocks@8.6.12':
     resolution: {integrity: sha512-DohlTq6HM1jDbHYiXL4ZvZ00VkhpUp5uftzj/CZDLY1fYHRjqtaTwWm2/OpceivMA8zDitLcq5atEZN+f+siTg==}
     peerDependencies:
@@ -4547,6 +4602,9 @@ packages:
     resolution: {integrity: sha512-HK7yQD4kFu04JOKnUwoFeR58r5WY6ucF0D8zfW4Gx+r8hBJ5K4t3z6k2dlIlRQF1X5+2vNkQOwD8liHjckuZ8Q==}
     peerDependencies:
       storybook: ^8.6.7
+
+  '@storybook/csf@0.1.11':
+    resolution: {integrity: sha512-dHYFQH3mA+EtnCkHXzicbLgsvzYjcDJ1JWsogbItZogkPHgSJM/Wr71uMkcvw8v9mmCyP4NpXJuu6bPoVsOnzg==}
 
   '@storybook/csf@0.1.12':
     resolution: {integrity: sha512-9/exVhabisyIVL0VxTCxo01Tdm8wefIXKXfltAPTSr8cbLn5JAxGQ6QV3mjdecLGEOucfoVhAKtJfVHxEK1iqw==}
@@ -4883,6 +4941,15 @@ packages:
   '@types/bonjour@3.5.13':
     resolution: {integrity: sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==}
 
+  '@types/color-convert@2.0.4':
+    resolution: {integrity: sha512-Ub1MmDdyZ7mX//g25uBAoH/mWGd9swVbt8BseymnaE18SU4po/PjmCrHxqIIRjBo3hV/vh1KGr0eMxUhp+t+dQ==}
+
+  '@types/color-name@1.1.5':
+    resolution: {integrity: sha512-j2K5UJqGTxeesj6oQuGpMgifpT5k9HprgQd8D1Y0lOFqKHl3PJu5GMeS4Y5EgjS55AE6OQxf8mPED9uaGbf4Cg==}
+
+  '@types/color@3.0.6':
+    resolution: {integrity: sha512-NMiNcZFRUAiUUCCf7zkAelY8eV3aKqfbzyFQlXpPIEeoNDbsEHGpb854V3gzTsGKYj830I5zPuOwU/TP5/cW6A==}
+
   '@types/concat-stream@2.0.3':
     resolution: {integrity: sha512-3qe4oQAPNwVNwK4C9c8u+VJqv9kez+2MR4qJpoPFfXtgxxif1QbFusvXzK0/Wra2VX07smostI2VMmJNSpZjuQ==}
 
@@ -4901,8 +4968,14 @@ packages:
   '@types/cross-spawn@6.0.6':
     resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
 
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/delta-e@0.0.2':
+    resolution: {integrity: sha512-DLvqCZ+ce6qVLp8HIxx8rrLjog1t0NlSLXOzz2FbYC31xHMSADMEz+MrJTvYTeuHez6Wtm0dDYgGtBY+7Dgf4Q==}
 
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
@@ -5362,6 +5435,10 @@ packages:
         optional: true
       vega:
         optional: true
+
+  '@utrecht/components@4.0.0':
+    resolution: {integrity: sha512-vpw8p5FEU/yrSGL5JU+x6bDXIreEPU6WPEagOkcdqbFGMovWS8uUHNWmv+PY1xJIOjOb98RebSsbFDoA4zllVQ==}
+    deprecated: 'The @utrecht/components package has been deprecated. To migrate: the SCSS files are now only available in the npm package for the specific component. For example: @utrecht/button-css/src/_mixin.scss. The entire component library is now available in @utrecht/component-library-css/dist/index.css.'
 
   '@utrecht/components@7.4.0':
     resolution: {integrity: sha512-LWFJjJ7TF0eaoWq5TGrg7rNYnG+G5yIEJhuiwFlbICwSx2n+gZVbAE1dAW8YG2mGqveXZk38hBC2FWNE1tj1BQ==}
@@ -6752,6 +6829,10 @@ packages:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
 
+  clsx@1.2.1:
+    resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
+    engines: {node: '>=6'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -6790,6 +6871,9 @@ packages:
   color-support@1.1.3:
     resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
     hasBin: true
+
+  color@3.2.1:
+    resolution: {integrity: sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==}
 
   color@4.2.3:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
@@ -7149,6 +7233,10 @@ packages:
     resolution: {integrity: sha512-YGZxdTTL9lmLkCUTpg4j0zQ7IhRB5ZmqNBbGCl3Tg6MP/d5/6sY7L5mmTjzbc6JKgVZYiqTQTNhPFsbXNGlRaA==}
     engines: {node: '>=0.8'}
 
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -7322,6 +7410,9 @@ packages:
 
   delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
+
+  delta-e@0.0.8:
+    resolution: {integrity: sha512-xIggbz7AoZLjwyV+BatfsKhWB1ejeh6vabM4KTJ2e7/d+TS0f7s87aUfkJ7B+MfniM6DD5VOWWlqcKXksp5mIg==}
 
   depd@1.1.2:
     resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
@@ -9754,17 +9845,29 @@ packages:
   lodash.clonedeep@4.5.0:
     resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
 
+  lodash.clonedeepwith@4.5.0:
+    resolution: {integrity: sha512-QRBRSxhbtsX1nc0baxSkkK5WlVTTm/s48DSukcGcWZwIyI8Zz+lB+kFiELJXtzfH4Aj6kMWQ1VWW4U5uUDgZMA==}
+
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
   lodash.flattendeep@4.4.0:
     resolution: {integrity: sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==}
 
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.mapvalues@4.6.0:
+    resolution: {integrity: sha512-JPFqXFeZQ7BfS00H58kClY7SPVeHertPE0lNuCyZ26/XlN8TvakYD7b9bGyNmXbT/D3BbtPAAmq90gPWqLkxlQ==}
+
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.omitby@4.6.0:
+    resolution: {integrity: sha512-5OrRcIVR75M288p4nbI2WLAf3ndw2GD9fyNv3Bc15+WCxJDdZ4lYndSxGd7hnG6PVjiJTeJE2dHEGhIuKGicIQ==}
 
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
@@ -9907,6 +10010,12 @@ packages:
   markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
     hasBin: true
+
+  markdown-to-jsx@7.7.12:
+    resolution: {integrity: sha512-Y5xNBqoaTooSLkmlg2P0fdbh53gp4MqW7zhvcweGCPUWvWI5BecWRYI8vPlzT8D7OULxsQg2qoRW9EsJlBWasQ==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      react: '>= 0.14.0'
 
   markdownlint-cli@0.43.0:
     resolution: {integrity: sha512-6vwurKK4B21eyYzwgX6ph13cZS7hE6LZfcS8QyD722CyxVD2RtAvbZK2p7k+FZbbKORulEuwl+hJaEq1l6/hoQ==}
@@ -11570,6 +11679,12 @@ packages:
   raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
     engines: {node: '>= 0.8'}
+
+  react-colorful@5.6.1:
+    resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   react-confetti@6.1.0:
     resolution: {integrity: sha512-7Ypx4vz0+g8ECVxr88W9zhcQpbeujJAVqL14ZnXJ3I23mOI9/oBVTQ3dkJhUmB0D6XOtCZEM6N0Gm9PMngkORw==}
@@ -15774,6 +15889,10 @@ snapshots:
       pirates: 4.0.6
       source-map-support: 0.5.21
 
+  '@babel/runtime@7.24.7':
+    dependencies:
+      regenerator-runtime: 0.14.1
+
   '@babel/runtime@7.26.10':
     dependencies:
       regenerator-runtime: 0.14.1
@@ -16264,6 +16383,38 @@ snapshots:
   '@fontsource/fira-sans@5.1.1': {}
 
   '@gar/promisify@1.1.3': {}
+
+  '@gemeente-denhaag/button@0.2.3-alpha.398(react@19.1.0)':
+    dependencies:
+      '@gemeente-denhaag/icons': 0.2.3-alpha.398(react@19.1.0)
+      react: 19.1.0
+
+  '@gemeente-denhaag/design-tokens-common@0.2.3-alpha.400': {}
+
+  '@gemeente-denhaag/design-tokens-components@0.2.3-alpha.400': {}
+
+  '@gemeente-denhaag/icons@0.2.3-alpha.398(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+
+  '@gemeente-denhaag/process-steps@0.1.0-alpha.227(react@19.1.0)':
+    dependencies:
+      '@gemeente-denhaag/button': 0.2.3-alpha.398(react@19.1.0)
+      '@gemeente-denhaag/icons': 0.2.3-alpha.398(react@19.1.0)
+      '@gemeente-denhaag/step-marker': 0.0.1-alpha.99(react@19.1.0)
+      '@gemeente-denhaag/typography': 0.2.3-alpha.398(react@19.1.0)
+      react: 19.1.0
+
+  '@gemeente-denhaag/step-marker@0.0.1-alpha.99(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+
+  '@gemeente-denhaag/typography@0.2.3-alpha.398(react@19.1.0)':
+    dependencies:
+      '@gemeente-denhaag/design-tokens-common': 0.2.3-alpha.400
+      '@gemeente-denhaag/design-tokens-components': 0.2.3-alpha.400
+      '@utrecht/components': 4.0.0
+      react: 19.1.0
 
   '@hapi/hoek@9.3.0': {}
 
@@ -17446,6 +17597,26 @@ snapshots:
       clsx: 2.1.1
       react: 19.1.0
 
+  '@nl-design-system-unstable/theme-toolkit@1.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.12(prettier@3.5.3))':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@gemeente-denhaag/process-steps': 0.1.0-alpha.227(react@19.1.0)
+      '@storybook/blocks': 8.2.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.12(prettier@3.5.3))
+      '@types/color': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/delta-e': 0.0.2
+      color: 3.2.1
+      d3-color: 3.1.0
+      delta-e: 0.0.8
+      lodash.clonedeepwith: 4.5.0
+      lodash.isplainobject: 4.0.6
+      lodash.mapvalues: 4.6.0
+      lodash.omitby: 4.6.0
+      react: 19.1.0
+    transitivePeerDependencies:
+      - react-dom
+      - storybook
+
   '@nl-design-system/tsconfig@1.0.3(typescript@5.8.3)':
     dependencies:
       typescript: 5.8.3
@@ -18434,6 +18605,27 @@ snapshots:
       - uglify-js
       - webpack-cli
 
+  '@storybook/blocks@8.2.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.12(prettier@3.5.3))':
+    dependencies:
+      '@storybook/csf': 0.1.11
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 1.2.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@types/lodash': 4.17.13
+      color-convert: 2.0.1
+      dequal: 2.0.3
+      lodash: 4.17.21
+      markdown-to-jsx: 7.7.12(react@19.1.0)
+      memoizerific: 1.11.3
+      polished: 4.3.1
+      react-colorful: 5.6.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      storybook: 8.6.12(prettier@3.5.3)
+      telejson: 7.2.0
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+    optionalDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
   '@storybook/blocks@8.6.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.12(prettier@3.5.3))':
     dependencies:
       '@storybook/icons': 1.2.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -18625,6 +18817,10 @@ snapshots:
       unplugin: 1.15.0(webpack-sources@3.2.3)
     transitivePeerDependencies:
       - webpack-sources
+
+  '@storybook/csf@0.1.11':
+    dependencies:
+      type-fest: 2.19.0
 
   '@storybook/csf@0.1.12':
     dependencies:
@@ -19054,6 +19250,16 @@ snapshots:
     dependencies:
       '@types/node': 20.17.6
 
+  '@types/color-convert@2.0.4':
+    dependencies:
+      '@types/color-name': 1.1.5
+
+  '@types/color-name@1.1.5': {}
+
+  '@types/color@3.0.6':
+    dependencies:
+      '@types/color-convert': 2.0.4
+
   '@types/concat-stream@2.0.3':
     dependencies:
       '@types/node': 20.17.6
@@ -19079,9 +19285,13 @@ snapshots:
     dependencies:
       '@types/node': 20.17.6
 
+  '@types/d3-color@3.1.3': {}
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 0.7.34
+
+  '@types/delta-e@0.0.2': {}
 
   '@types/doctrine@0.0.9': {}
 
@@ -19792,6 +20002,10 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
       date-fns: 2.30.0
+
+  '@utrecht/components@4.0.0':
+    dependencies:
+      clsx: 1.2.1
 
   '@utrecht/components@7.4.0':
     dependencies:
@@ -21429,6 +21643,8 @@ snapshots:
 
   clone@1.0.4: {}
 
+  clsx@1.2.1: {}
+
   clsx@2.1.1: {}
 
   cmd-shim@6.0.3: {}
@@ -21458,9 +21674,13 @@ snapshots:
     dependencies:
       color-name: 1.1.4
       simple-swizzle: 0.2.2
-    optional: true
 
   color-support@1.1.3: {}
+
+  color@3.2.1:
+    dependencies:
+      color-convert: 1.9.3
+      color-string: 1.9.1
 
   color@4.2.3:
     dependencies:
@@ -21916,6 +22136,8 @@ snapshots:
       find-pkg: 0.1.2
       fs-exists-sync: 0.1.0
 
+  d3-color@3.1.0: {}
+
   damerau-levenshtein@1.0.8: {}
 
   dargs@8.1.0: {}
@@ -22068,6 +22290,8 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   delegates@1.0.0: {}
+
+  delta-e@0.0.8: {}
 
   depd@1.1.2: {}
 
@@ -24083,8 +24307,7 @@ snapshots:
 
   is-arrayish@0.2.1: {}
 
-  is-arrayish@0.3.2:
-    optional: true
+  is-arrayish@0.3.2: {}
 
   is-async-function@2.0.0:
     dependencies:
@@ -25366,13 +25589,21 @@ snapshots:
 
   lodash.clonedeep@4.5.0: {}
 
+  lodash.clonedeepwith@4.5.0: {}
+
   lodash.debounce@4.0.8: {}
 
   lodash.flattendeep@4.4.0: {}
 
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.mapvalues@4.6.0: {}
+
   lodash.memoize@4.1.2: {}
 
   lodash.merge@4.6.2: {}
+
+  lodash.omitby@4.6.0: {}
 
   lodash.startcase@4.4.0: {}
 
@@ -25577,6 +25808,10 @@ snapshots:
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
+
+  markdown-to-jsx@7.7.12(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   markdownlint-cli@0.43.0:
     dependencies:
@@ -27077,7 +27312,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.26.2
       index-to-position: 0.1.2
-      type-fest: 4.26.1
+      type-fest: 4.38.0
 
   parse-node-version@1.0.1: {}
 
@@ -27641,6 +27876,11 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
+  react-colorful@5.6.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
   react-confetti@6.1.0(react@19.0.0):
     dependencies:
       react: 19.0.0
@@ -27725,7 +27965,7 @@ snapshots:
     dependencies:
       find-up: 6.3.0
       read-pkg: 8.1.0
-      type-fest: 4.26.1
+      type-fest: 4.38.0
 
   read-pkg-up@7.0.1:
     dependencies:
@@ -27751,14 +27991,14 @@ snapshots:
       '@types/normalize-package-data': 2.4.4
       normalize-package-data: 6.0.2
       parse-json: 7.1.1
-      type-fest: 4.26.1
+      type-fest: 4.38.0
 
   read-pkg@9.0.1:
     dependencies:
       '@types/normalize-package-data': 2.4.4
       normalize-package-data: 6.0.2
       parse-json: 8.1.0
-      type-fest: 4.26.1
+      type-fest: 4.38.0
       unicorn-magic: 0.1.0
 
   read-yaml-file@1.1.0:
@@ -28522,7 +28762,6 @@ snapshots:
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
-    optional: true
 
   sisteransi@1.0.5: {}
 
@@ -30267,7 +30506,7 @@ snapshots:
       deepmerge-ts: 7.1.3
       read-pkg: 9.0.1
       sort-keys: 5.1.0
-      type-fest: 4.26.1
+      type-fest: 4.38.0
       write-json-file: 6.0.0
 
   ws@8.17.1:


### PR DESCRIPTION
Controle op alle thema's en alle(/zoveel mogelijk) states bij visuele regressie van een component, op een gelijke manier als in  nl-design-system/lux (gebruik/license is opgenomen in code)
Voor nu alleen button en link.