### PR TITLE
fix: match github discussion category to template name #1717

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/rijkshuisstijl-2025-interpretatie.yml
+++ b/.github/DISCUSSION_TEMPLATE/rijkshuisstijl-2025-interpretatie.yml
@@ -1,7 +1,7 @@
 title: "{Naam van het onderdeel}"
 body:
   - type: textarea
-    id: rijkshuisstijl-interpretatie
+    id: rijkshuisstijl-2025-interpretatie
     attributes:
       label: Rijkshuisstijl interpretatie
       value: |


### PR DESCRIPTION
Fixes https://github.com/nl-design-system/rijkshuisstijl-community/issues/1717#issuecomment-3233502456 "De template werkt niet als ik een nieuwe Discussion start. Uitzoeken waarom dit niet werkt."