### PR TITLE
Remove koop thema

### DIFF
--- a/.changeset/hip-pumas-battle.md
+++ b/.changeset/hip-pumas-battle.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/design-tokens': major
+---
+
+removed koop theme due to it not being used

--- a/packages/storybook-angular/.storybook/preview.ts
+++ b/packages/storybook-angular/.storybook/preview.ts
@@ -32,7 +32,6 @@ const preview: Preview = {
         'Uitvoerend - violet': 'uitvoerend-violet',
         'Uitvoerend - mintgroen': 'uitvoerend-mintgroen',
         'Uitvoerend - violet - oud': 'uitvoerend-violet-oud',
-        KOOP: 'koop',
       },
       defaultTheme: 'RijkshuisstijlCommunity',
     }),

--- a/packages/storybook-angular/src/styles.scss
+++ b/packages/storybook-angular/src/styles.scss
@@ -8,7 +8,6 @@
 @import "@rijkshuisstijl-community/design-tokens/dist/uitvoerend-oranje/index.css";
 @import "@rijkshuisstijl-community/design-tokens/dist/uitvoerend-groen/index.css";
 @import "@rijkshuisstijl-community/design-tokens/dist/uitvoerend-hemelblauw/index.css";
-@import "@rijkshuisstijl-community/design-tokens/dist/koop/index.css";
 @import "@rijkshuisstijl-community/digid-design-tokens/dist/theme.css";
 @import "@rijkshuisstijl-community/font/src/index";
 @import "@rijkshuisstijl-community/logius-design-tokens/dist/theme.css";

--- a/packages/storybook/config/preview.tsx
+++ b/packages/storybook/config/preview.tsx
@@ -7,7 +7,6 @@ import '@rijkshuisstijl-community/design-tokens/dist/uitvoerend-paars/index.css'
 import '@rijkshuisstijl-community/design-tokens/dist/uitvoerend-oranje/index.css';
 import '@rijkshuisstijl-community/design-tokens/dist/uitvoerend-groen/index.css';
 import '@rijkshuisstijl-community/design-tokens/dist/uitvoerend-hemelblauw/index.css';
-import '@rijkshuisstijl-community/design-tokens/dist/koop/index.css';
 import '@rijkshuisstijl-community/digid-design-tokens/dist/theme.css';
 import '@rijkshuisstijl-community/font/src/index.mjs';
 import '@rijkshuisstijl-community/logius-design-tokens/dist/theme.css';
@@ -39,7 +38,6 @@ const preview: Preview = {
         'Uitvoerend - violet': 'uitvoerend-violet',
         'Uitvoerend - mintgroen': 'uitvoerend-mintgroen',
         'Uitvoerend - violet - oud': 'uitvoerend-violet-oud',
-        KOOP: 'koop',
       },
       defaultTheme: 'RijkshuisstijlCommunity',
     }),

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -9665,52 +9665,6 @@
       }
     }
   },
-  "overwrites/koop/link": {
-    "nl": {
-      "link": {
-        "active": {
-          "color": {
-            "value": "#800080",
-            "type": "color"
-          }
-        },
-        "focus": {
-          "text-decoration-thickness": {
-            "value": "1px",
-            "type": "other"
-          }
-        },
-        "hover": {
-          "text-decoration-line": {
-            "value": "underline",
-            "type": "textDecoration"
-          },
-          "text-decoration-thickness": {
-            "value": "2px",
-            "type": "other"
-          },
-          "color": {
-            "value": "#0F2E51",
-            "type": "color"
-          }
-        },
-        "text-decoration-line": {
-          "value": "underline",
-          "type": "textDecoration"
-        },
-        "text-decoration-thickness": {
-          "value": "1px",
-          "type": "other"
-        },
-        "visited": {
-          "color": {
-            "value": "#800080",
-            "type": "color"
-          }
-        }
-      }
-    }
-  },
   "$themes": [
     {
       "id": "05865788a086eeac7ffc4514736ccd777f1ff95c",
@@ -10496,107 +10450,6 @@
       },
       "$figmaVariableReferences": {},
       "group": "Rijkshuisstijl"
-    },
-    {
-      "id": "901f351a9ecb6f245825f6459690799f36e109a0",
-      "name": "KOOP",
-      "$figmaStyleReferences": {},
-      "selectedTokenSets": {
-        "brand/color": "enabled",
-        "brand/space": "enabled",
-        "brand/border": "enabled",
-        "brand/font": "enabled",
-        "brand/size": "enabled",
-        "common/color": "enabled",
-        "common/size": "enabled",
-        "common/font": "enabled",
-        "common/focus": "enabled",
-        "common/border": "enabled",
-        "utrecht/focus": "enabled",
-        "utrecht/pointer-target": "enabled",
-        "utrecht/rich-text": "enabled",
-        "utrecht/document": "enabled",
-        "components/article": "enabled",
-        "components/card-as-link": "enabled",
-        "components/checkbox-group": "enabled",
-        "components/code-input-group": "enabled",
-        "components/code-input": "enabled",
-        "components/data-summary": "enabled",
-        "components/dot-badge": "enabled",
-        "components/fieldset": "enabled",
-        "components/file-input": "enabled",
-        "components/footer": "enabled",
-        "components/form-field-checkbox-option": "enabled",
-        "components/form-field-option-label": "enabled",
-        "components/form-field-radio-option": "enabled",
-        "components/heading/nl": "enabled",
-        "components/hero": "enabled",
-        "components/icon": "enabled",
-        "components/icon-only-button": "enabled",
-        "components/link/nl": "enabled",
-        "components/link/utrecht": "enabled",
-        "components/link-list-card": "enabled",
-        "components/logo": "enabled",
-        "components/message-list": "enabled",
-        "components/nav-bar": "enabled",
-        "components/navigation-list": "enabled",
-        "components/paragraph/nl": "enabled",
-        "components/pre-heading": "enabled",
-        "components/radio-group": "enabled",
-        "components/separator": "enabled",
-        "components/side-nav": "enabled",
-        "components/skip-link/nl": "enabled",
-        "components/status-badge": "enabled",
-        "components/sub-nav-bar": "enabled",
-        "components/table": "enabled",
-        "components/toggletip": "enabled",
-        "components/column-layout": "enabled",
-        "overwrites/footer/lintblauw-background": "enabled",
-        "overwrites/nav-bar/lintblauw-outline": "enabled",
-        "overwrites/closed-source/font": "enabled",
-        "components/action-group": "enabled",
-        "overwrites/koop/link": "enabled",
-        "components/ordered-list": "enabled",
-        "components/unordered-list": "enabled",
-        "utrecht/action": "enabled",
-        "common/rounded-corner/base": "enabled",
-        "common/rounded-corner/deprecated": "enabled",
-        "components/link-list/base": "enabled",
-        "components/breadcrumb": "enabled",
-        "components/button": "enabled",
-        "components/data-badge": "enabled",
-        "components/data-badge-button": "enabled",
-        "components/accordion/base": "enabled",
-        "components/alert": "enabled",
-        "components/accordion/deprecated": "enabled",
-        "components/blockquote/base": "enabled",
-        "components/blockquote/deprecated": "enabled",
-        "components/number-badge/nl": "enabled",
-        "components/number-badge/utrecht": "enabled",
-        "components/figure/base": "enabled",
-        "components/figure/deprecated": "enabled",
-        "components/number-badge/deprecated": "enabled",
-        "components/form-field-description/base": "enabled",
-        "components/form-field-error-message/base": "enabled",
-        "components/textarea/base": "enabled",
-        "components/form-field-label/utrecht": "enabled",
-        "components/form-field-description/deprecated": "enabled",
-        "components/form-field-error-message/deprecated": "enabled",
-        "components/form-field-label/todo": "enabled",
-        "components/textarea/deprecated": "enabled",
-        "components/text-input/base": "enabled",
-        "components/radio-button/base": "enabled",
-        "components/checkbox/base": "enabled",
-        "components/select/base": "enabled",
-        "components/form-field/base": "enabled",
-        "components/checkbox/deprecated": "enabled",
-        "components/form-field/deprecated": "enabled",
-        "components/radio-button/deprecated": "enabled",
-        "components/select/deprecated": "enabled",
-        "components/text-input/deprecated": "enabled"
-      },
-      "$figmaVariableReferences": {},
-      "group": "Rijkshuisstijl"
     }
   ],
   "$metadata": {
@@ -10718,8 +10571,7 @@
       "overwrites/responsive/tablet",
       "overwrites/font-weight/bzk",
       "overwrites/closed-source/font",
-      "overwrites/afwijkende keuzes/button",
-      "overwrites/koop/link"
+      "overwrites/afwijkende keuzes/button"
     ]
   }
 }


### PR DESCRIPTION
Nu de koop link underscore styling overgenomen is is het niet meer nodig om een apparte styling te hebben voor KOOP 