### PR TITLE
Misc storybook fixes

### DIFF
--- a/.changeset/fancy-times-double.md
+++ b/.changeset/fancy-times-double.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/components-angular': patch
+---
+
+The chevron icons inside the footer now get placed in the proper place in the DOM.

--- a/.changeset/orange-beans-shine.md
+++ b/.changeset/orange-beans-shine.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/storybook-angular': minor
+---
+
+Footer now has relative import for hot reload and added missing icons in Link list stories.

--- a/.changeset/orange-beans-shine.md
+++ b/.changeset/orange-beans-shine.md
@@ -1,5 +1,0 @@
----
-'@rijkshuisstijl-community/storybook-angular': minor
----
-
-Footer now has relative import for hot reload and added missing icons in Link list stories.

--- a/packages/components-angular/src/footer/footer.component.html
+++ b/packages/components-angular/src/footer/footer.component.html
@@ -30,7 +30,7 @@
             @for (item of column.items; track $index) {
               <li rhc-link-list-item>
                 <a rhc-link-list-link [href]="item.href" [attr.href]="item.href">
-                  <rhc-icon
+                  <rhc-icon icon
                     ><svg
                       xmlns="http://www.w3.org/2000/svg"
                       width="24"

--- a/packages/storybook-angular/src/stories/footer.stories.ts
+++ b/packages/storybook-angular/src/stories/footer.stories.ts
@@ -1,6 +1,6 @@
-import { FooterComponent } from '@rijkshuisstijl-community/components-angular';
 import { type Meta, type StoryObj } from '@storybook/angular';
 import readme from './footer.md';
+import { FooterComponent } from '../../../components-angular/src/public-api';
 
 const meta: Meta<FooterComponent> = {
   title: 'Rijkshuisstijl/Footer',

--- a/packages/storybook-angular/src/stories/link-list.stories.ts
+++ b/packages/storybook-angular/src/stories/link-list.stories.ts
@@ -42,19 +42,19 @@ const meta: Meta<StoryType> = {
       <rhc-link-list>
         <li rhc-link-list-item>
           <a rhc-link-list-link href="#">
-            ${hasIcons ? "<rhc-icon icon='chevron-right' />" : ''}
+            ${hasIcons ? `<rhc-icon icon><svg  xmlns="http://www.w3.org/2000/svg"  width="24"  height="24"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round"  class="tabler-icon tabler-icon-chevron-right "><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M9 6l6 6l-6 6" /></svg></rhc-icon>` : ''}
             Learn about <i lang="fr">joi de vivre</i>, an essential foreign phrase!
           </a>
         </li>
         <li rhc-link-list-item>
           <a rhc-link-list-link href="#">
-            ${hasIcons ? "<rhc-icon icon='chevron-right' />" : ''}
+            ${hasIcons ? `<rhc-icon icon><svg  xmlns="http://www.w3.org/2000/svg"  width="24"  height="24"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round"  class="tabler-icon tabler-icon-chevron-right "><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M9 6l6 6l-6 6" /></svg></rhc-icon>` : ''}
             Link 2
           </a>
         </li>
         <li rhc-link-list-item>
           <a rhc-link-list-link href="#">
-            ${hasIcons ? "<rhc-icon icon='chevron-right' />" : ''}
+            ${hasIcons ? `<rhc-icon icon><svg  xmlns="http://www.w3.org/2000/svg"  width="24"  height="24"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round"  class="tabler-icon tabler-icon-chevron-right "><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M9 6l6 6l-6 6" /></svg></rhc-icon>` : ''}
             Link 3
           </a>
         </li>
@@ -77,19 +77,19 @@ export const ColumnsLayout: StoryObj<LinkListComponent> = {
       <rhc-link-list>
         <li rhc-link-list-item>
           <a rhc-link-list-link href="#">
-            <rhc-icon icon='chevron-right' />
+            <rhc-icon icon><svg  xmlns="http://www.w3.org/2000/svg"  width="24"  height="24"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round"  class="tabler-icon tabler-icon-chevron-right "><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M9 6l6 6l-6 6" /></svg></rhc-icon>
             Learn about <i lang="fr">joi de vivre</i>, an essential foreign phrase!
           </a>
         </li>
         <li rhc-link-list-item>
           <a rhc-link-list-link href="#">
-            <rhc-icon icon='chevron-right' />
+            <rhc-icon icon><svg  xmlns="http://www.w3.org/2000/svg"  width="24"  height="24"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round"  class="tabler-icon tabler-icon-chevron-right "><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M9 6l6 6l-6 6" /></svg></rhc-icon>
             Link 2
           </a>
         </li>
         <li rhc-link-list-item>
           <a rhc-link-list-link href="#">
-            <rhc-icon icon='chevron-right' />
+            <rhc-icon icon><svg  xmlns="http://www.w3.org/2000/svg"  width="24"  height="24"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round"  class="tabler-icon tabler-icon-chevron-right "><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M9 6l6 6l-6 6" /></svg></rhc-icon>
             Link 3
           </a>
         </li>


### PR DESCRIPTION
Footer now has relative import for hot reload and added missing icons in Link list stories. The chevron icons inside the footer now get placed in the proper place in the DOM.