### PR TITLE
fix: always reference dist in components react package.json

### DIFF
--- a/.changeset/silly-phones-serve.md
+++ b/.changeset/silly-phones-serve.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/components-react': patch
+---
+
+In development environments the package.json was referencing non existing files.

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -37,7 +37,9 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.esm.js",
       "require": "./dist/index.cjs.js"
-    }
+    },
+    "./CHANGELOG.md": "./CHANGELOG.md",
+    "./README.md": "./README.md"
   },
   "files": [
     "dist/"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -34,15 +34,10 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "default": {
-        "types": "./dist/index.d.ts",
-        "import": "./dist/index.esm.js",
-        "require": "./dist/index.cjs.js"
-      }
-    },
-    "./CHANGELOG.md": "./CHANGELOG.md",
-    "./README.md": "./README.md"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.cjs.js"
+    }
   },
   "files": [
     "dist/"


### PR DESCRIPTION
To improve hot reloading we had references source files directly in a development environment. But this also happens in the development environments of the consuming applications where the sources files are not available. 