### PR TITLE
fix: add custom condition for source mapping

### DIFF
--- a/.changeset/chatty-worms-beg.md
+++ b/.changeset/chatty-worms-beg.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/components-react': patch
+---
+
+Improved developer experiance for this monorepo

--- a/.changeset/chatty-worms-beg.md
+++ b/.changeset/chatty-worms-beg.md
@@ -2,4 +2,4 @@
 '@rijkshuisstijl-community/components-react': patch
 ---
 
-Improved developer experiance for this monorepo
+Improved developer experience for this monorepo

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -34,9 +34,12 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.esm.js",
-      "require": "./dist/index.cjs.js"
+      "rhc:source": "./src/index.ts",
+      "default": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.esm.js",
+        "require": "./dist/index.cjs.js"
+      }
     },
     "./CHANGELOG.md": "./CHANGELOG.md",
     "./README.md": "./README.md"

--- a/packages/storybook/vite.config.mjs
+++ b/packages/storybook/vite.config.mjs
@@ -12,4 +12,8 @@ export default defineConfig({
       framework: 'react',
     }),
   ],
+  resolve: {
+    // we set the rhc:source so that the react package resolves directly to the source files for development in this monorepo
+    conditions: ['rhc:source', 'import', 'require', 'default'],
+  },
 });


### PR DESCRIPTION
No longer tie the source mapping to just being in a dev environment as this would trigger for users of the package in there own developer environment causing references to non bundled source files. 

Now it will only resolve the source files if you provide the custom rhc:source condition to the build tool of the consuming package. 