### PR TITLE
feat: chevron icon in NavigationList aanpasbaar maken (#2074)

### DIFF
--- a/.changeset/odd-walls-stay.md
+++ b/.changeset/odd-walls-stay.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/components-react': minor
+---
+
+Added `iconEnd` property to `NavigationListItem` component. The icon end used to be `chevron-end` and not customizable. Now it is optionally customizable. The default value is `chevron-end`. With this, it is not a breaking change and does not affect existing usage of the component.

--- a/packages/components-react/src/NavigationListItem.tsx
+++ b/packages/components-react/src/NavigationListItem.tsx
@@ -8,6 +8,7 @@ export interface NavigationListItemProps extends HTMLAttributes<HTMLLIElement> {
   label: ReactNode;
   description: ReactNode;
   icon: RHCIconID | ReactNode;
+  iconEnd?: RHCIconID | ReactNode;
   href: string;
   ref?: Ref<HTMLLIElement>;
 }
@@ -18,6 +19,7 @@ export const NavigationListItem = ({
   href,
   description,
   icon,
+  iconEnd = 'chevron-right',
   className,
   ...restProps
 }: NavigationListItemProps) => {
@@ -32,7 +34,11 @@ export const NavigationListItem = ({
         <span className={'rhc-navigation-list__item-content'}>
           <Paragraph className={'rhc-navigation-list__item__label'}>{label}</Paragraph>
           <Paragraph className={'rhc-navigation-list__item__description'}>{description}</Paragraph>
-          <Icon className={'rhc-navigation-list__item__end-icon'} icon={'chevron-right'} />
+          {typeof iconEnd === 'string' ? (
+            <Icon className={'rhc-navigation-list__item__end-icon'} icon={iconEnd as RHCIconID} />
+          ) : (
+            <Icon className={'rhc-navigation-list__item__end-icon'}>{iconEnd}</Icon>
+          )}
         </span>
       </a>
     </li>

--- a/packages/storybook/src/components-css/navigation-list-item.stories.tsx
+++ b/packages/storybook/src/components-css/navigation-list-item.stories.tsx
@@ -10,5 +10,6 @@ export default {
 
 export const Default = ReactStories.Default;
 export const WithCustomIcon = ReactStories.WithCustomIcon;
+export const WithCustomIconEnd = ReactStories.WithCustomIconEnd;
 export const Hover = ReactStories.Hover;
 export const Focus = ReactStories.Focus;

--- a/packages/storybook/src/components-react/navigation-list-item.stories.tsx
+++ b/packages/storybook/src/components-react/navigation-list-item.stories.tsx
@@ -81,6 +81,27 @@ export const WithCustomIcon: Story = {
   },
 };
 
+export const WithCustomIconEnd: Story = {
+  args: {
+    iconEnd: (
+      <svg
+        fill="none"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path d="M17 7l-10 10"></path>
+        <path d="M8 7l9 0l0 9"></path>
+      </svg>
+    ),
+  },
+};
+
 export const Hover: Story = {
   parameters: {
     pseudo: { hover: true },


### PR DESCRIPTION
Maken gebruik van iconEnd, welke overeenkomt met de afgesproken design tokens voor dit icon.

Voorheen was dit altijd 'chevron-right'. Nu kan je 'm aanpassen. Hij is optioneel aanpasbaar, en de default waarde is 'chevron-right'. Zo is hij niet breaking en heeft het geen impact voor bestaande afnemers.