### PR TITLE
chore: upgrade pnpm to 10.28.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "engines": {
     "//": "Update @types/node to match the highest node version here",
     "node": ">=24 <=25",
-    "pnpm": "^10.16.0"
+    "pnpm": "^10.17.0"
   },
   "workspaces": [
     "./apps/**",


### PR DESCRIPTION
This PR:
- Upgrades pnpm to the latest version
- Ensures that the minimum version (10.17.0) is properly set in package.json; this minimum version is required for security features, to be exact, minimumReleaseAgeExclude patterns