### PR TITLE
build: ignore critical vulnerability

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,6 +43,10 @@ minimumReleaseAgeExclude:
 saveExact: true
 savePrefix: ""
 
+auditConfig:
+  ignoreGhsas:
+    - GHSA-vh9h-29pq-r5m8
+
 overrides:
   locutus@>=2.0.12 <2.0.39: ">=2.0.39"
   "@isaacs/brace-expansion@<=5.0.0": ">=5.0.1"


### PR DESCRIPTION
GHSA-vh9h-29pq-r5m8

- The dependency `twig.js` does not use `create_function` from `locutus`
- The dependency `drupal-twig-extensions` only uses `date` from `locutus` https://github.com/search?q=repo%3AJohnAlbin%2Fdrupal-twig-extensions%20locutus&type=code