### PR TITLE
chore: fix dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     groups:
       github-actions:
         applies-to: "version-updates"
+        patterns:
+          - "*"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:


### PR DESCRIPTION
Fixes
```
Dependabot encountered the following error when parsing your .github/dependabot.yml:

The property '#/updates/0/groups/github-actions' of type object did not match one or more of the required schemas

Please update the config file to conform with Dependabot's specification.
```