### PR TITLE
style: fixed hue

### DIFF
--- a/.changeset/polite-owls-count.md
+++ b/.changeset/polite-owls-count.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/design-tokens': patch
+---
+
+Color tints and shades now have the same hue as the base color, using `rhc-theme--fixed-hue`.

--- a/.changeset/wild-times-glow.md
+++ b/.changeset/wild-times-glow.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/design-tokens': patch
+---
+
+CSS now uses `oklch()` colors instead of hex-colors.

--- a/apps/rhc-templates/src/app/layout.tsx
+++ b/apps/rhc-templates/src/app/layout.tsx
@@ -18,6 +18,7 @@ import '@rijkshuisstijl-community/design-tokens/src/fluid.css';
 import '@rijkshuisstijl-community/design-tokens/src/fluid-font-size.css';
 import '@rijkshuisstijl-community/design-tokens/src/fluid-space.css';
 import '@rijkshuisstijl-community/design-tokens/src/dark-mode.css';
+import '@rijkshuisstijl-community/design-tokens/src/color-oklch.css';
 
 export const metadata: Metadata = {
   title: {
@@ -28,7 +29,11 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: PropsWithChildren<{}>) {
   return (
-    <Root lang="nl" dir="ltr" className="rhc-theme rhc-theme--fluid-font-size rhc-theme--dark-mode">
+    <Root
+      lang="nl"
+      dir="ltr"
+      className="rhc-theme rhc-theme--fluid-font-size rhc-theme--dark-mode rhc-theme--fixed-hue"
+    >
       <Body>
         <PageLayout>{children}</PageLayout>
       </Body>

--- a/packages/storybook/.storybook/preview.tsx
+++ b/packages/storybook/.storybook/preview.tsx
@@ -9,6 +9,7 @@ import '@rijkshuisstijl-community/design-tokens/dist/uitvoerend-lintblauw/index.
 import '@rijkshuisstijl-community/design-tokens/src/fluid.css';
 import '@rijkshuisstijl-community/design-tokens/src/fluid-font-size.css';
 import '@rijkshuisstijl-community/design-tokens/src/fluid-space.css';
+import '@rijkshuisstijl-community/design-tokens/src/color-oklch.css';
 import '@rijkshuisstijl-community/font/src/index.mjs';
 import '@rijkshuisstijl-community/components-css/dist/index.css';
 import { Body, PageLayout, Paragraph, Root } from '@rijkshuisstijl-community/components-react';
@@ -25,7 +26,7 @@ const preview: Preview = {
   decorators: [
     withThemeByClassName({
       themes: {
-        'Kern - Lintblauw': 'rhc-theme rhc-theme--fluid-font-size',
+        'Kern - Lintblauw': 'rhc-theme rhc-theme--fluid-font-size rhc-theme--fixed-hue',
         'Uitvoerend - Groen': 'uitvoerend-groen',
         'Uitvoerend - Hemelblauw': 'uitvoerend-hemelblauw',
         'Uitvoerend - Lintblauw': 'uitvoerend-lintblauw',

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -174,6 +174,11 @@
           "500": {
             "$type": "color",
             "$value": "#007bc7"
+          },
+          "700": {
+            "$type": "color",
+            "$value": "#1A4972",
+            "$description": "Originally rhc.color.hemelblauw.500 darkened (lch) with modify by 0.4"
           }
         },
         "donkerblauw": {
@@ -200,6 +205,16 @@
           "500": {
             "$type": "color",
             "$value": "#01689b"
+          },
+          "600": {
+            "$type": "color",
+            "$value": "#01496c",
+            "$description": "Originally rhc.color.donkerblauw.500 darkened (srgb) with modify by 0.3"
+          },
+          "700": {
+            "$type": "color",
+            "$value": "#163f5b",
+            "$description": "Originally rhc.color.donkerblauw.500 darkened (lch) by 0.4"
           }
         },
         "mintgroen": {
@@ -538,6 +553,16 @@
           "500": {
             "$type": "color",
             "$value": "#154273"
+          },
+          "600": {
+            "$type": "color",
+            "$value": "#162f50",
+            "$description": "Originally rhc.color.primary.500 darkened (lch) by 0.3"
+          },
+          "700": {
+            "$type": "color",
+            "$value": "#162945",
+            "$description": "Originally rhc.color.primary.500 darkened (lch) by 0.4"
           }
         },
         "wit": {
@@ -547,6 +572,559 @@
         "zwart": {
           "$type": "color",
           "$value": "#000"
+        },
+        "transparent": {
+          "$type": "color",
+          "$value": "transparent"
+        }
+      }
+    }
+  },
+  "brand/color-oklch": {
+    "rhc": {
+      "color": {
+        "cool-grey": {
+          "50": {
+            "$type": "color",
+            "$value": "oklch(98.4% 0.003 247.858)"
+          },
+          "100": {
+            "$type": "color",
+            "$value": "oklch(96.8% 0.007 247.896)"
+          },
+          "200": {
+            "$type": "color",
+            "$value": "oklch(92.9% 0.013 255.508)"
+          },
+          "300": {
+            "$type": "color",
+            "$value": "oklch(86.9% 0.022 252.894)"
+          },
+          "400": {
+            "$type": "color",
+            "$value": "oklch(70.4% 0.04 256.788)"
+          },
+          "500": {
+            "$type": "color",
+            "$value": "oklch(55.1% 0.027 264.364)"
+          },
+          "600": {
+            "$type": "color",
+            "$value": "oklch(44.6% 0.043 257.281)"
+          },
+          "700": {
+            "$type": "color",
+            "$value": "oklch(37.2% 0.044 257.287)"
+          },
+          "800": {
+            "$type": "color",
+            "$value": "oklch(27.9% 0.041 260.031)"
+          },
+          "900": {
+            "$type": "color",
+            "$value": "oklch(20.8% 0.042 265.755)"
+          }
+        },
+        "lichtblauw": {
+          "500": {
+            "$type": "color",
+            "$value": "oklch(80.882% 0.07312 230.01)"
+          },
+          "400": {
+            "$type": "color",
+            "$value": "oklch(85.658% 0.05394 230.62)"
+          },
+          "300": {
+            "$type": "color",
+            "$value": "oklch(88.524% 0.04276 230.92)"
+          },
+          "200": {
+            "$type": "color",
+            "$value": "oklch(91.392% 0.03181 231.19)"
+          },
+          "100": {
+            "$type": "color",
+            "$value": "oklch(94.26% 0.02104 231.42)"
+          },
+          "50": {
+            "$type": "color",
+            "$value": "oklch(97.13% 0.01044 231.63)"
+          }
+        },
+        "violet": {
+          "500": {
+            "$type": "color",
+            "$value": "oklch(47.91% 0.19619 355.91)"
+          },
+          "400": {
+            "$type": "color",
+            "$value": "oklch(60.893% 0.14403 355.92)"
+          },
+          "300": {
+            "$type": "color",
+            "$value": "oklch(68.7% 0.11406 355.91)"
+          },
+          "200": {
+            "$type": "color",
+            "$value": "oklch(76.516% 0.08481 355.91)"
+          },
+          "100": {
+            "$type": "color",
+            "$value": "oklch(84.339% 0.05612 355.9)"
+          },
+          "50": {
+            "$type": "color",
+            "$value": "oklch(92.167% 0.02788 355.89)"
+          }
+        },
+        "paars": {
+          "500": {
+            "$type": "color",
+            "$value": "oklch(30.782% 0.12693 308.6)"
+          },
+          "400": {
+            "$type": "color",
+            "$value": "oklch(47.901% 0.09917 312.44)"
+          },
+          "300": {
+            "$type": "color",
+            "$value": "oklch(58.278% 0.07991 313.54)"
+          },
+          "200": {
+            "$type": "color",
+            "$value": "oklch(68.687% 0.06012 314.28)"
+          },
+          "100": {
+            "$type": "color",
+            "$value": "oklch(79.114% 0.04013 314.83)"
+          },
+          "50": {
+            "$type": "color",
+            "$value": "oklch(89.553% 0.02007 315.24)"
+          }
+        },
+        "hemelblauw": {
+          "700": {
+            "$type": "color",
+            "$value": "oklch(39.49% 0.086 248.3)",
+            "$description": "Originally rhc.color.hemelblauw.500 darkened (lch) with modify by 0.4"
+          },
+          "500": {
+            "$type": "color",
+            "$value": "oklch(56.621% 0.1475 246.59)"
+          },
+          "400": {
+            "$type": "color",
+            "$value": "oklch(67.426% 0.10487 252.37)"
+          },
+          "300": {
+            "$type": "color",
+            "$value": "oklch(73.922% 0.08205 254.75)"
+          },
+          "200": {
+            "$type": "color",
+            "$value": "oklch(80.43% 0.06043 256.6)"
+          },
+          "100": {
+            "$type": "color",
+            "$value": "oklch(86.946% 0.03966 258.06)"
+          },
+          "50": {
+            "$type": "color",
+            "$value": "oklch(93.47% 0.01956 259.24)"
+          }
+        },
+        "donkerblauw": {
+          "700": {
+            "$type": "color",
+            "$value": "oklch(35.32% 0.0666 242.1)",
+            "$description": "Originally rhc.color.donkerblauw.500 darkened (lch) by 0.4"
+          },
+          "600": {
+            "$type": "color",
+            "$value": "oklch(38.54% 0.0857 238.6)",
+            "$description": "Originally rhc.color.donkerblauw.500 darkened (srgb) with modify by 0.3"
+          },
+          "500": {
+            "$type": "color",
+            "$value": "oklch(49.37% 0.11351 240.39)"
+          },
+          "400": {
+            "$type": "color",
+            "$value": "oklch(62.004% 0.08026 244.97)"
+          },
+          "300": {
+            "$type": "color",
+            "$value": "oklch(69.594% 0.06272 246.69)"
+          },
+          "200": {
+            "$type": "color",
+            "$value": "oklch(77.189% 0.04617 247.98)"
+          },
+          "100": {
+            "$type": "color",
+            "$value": "oklch(84.789% 0.03031 248.96)"
+          },
+          "50": {
+            "$type": "color",
+            "$value": "oklch(92.393% 0.01496 249.73)"
+          }
+        },
+        "mintgroen": {
+          "500": {
+            "$type": "color",
+            "$value": "oklch(79.855% 0.0978 171.97)"
+          },
+          "400": {
+            "$type": "color",
+            "$value": "oklch(84.884% 0.07397 172.02)"
+          },
+          "300": {
+            "$type": "color",
+            "$value": "oklch(87.904% 0.05943 172.04)"
+          },
+          "200": {
+            "$type": "color",
+            "$value": "oklch(90.925% 0.04475 172.06)"
+          },
+          "100": {
+            "$type": "color",
+            "$value": "oklch(93.949% 0.02995 172.08)"
+          },
+          "50": {
+            "$type": "color",
+            "$value": "oklch(96.974% 0.01502 172.1)"
+          }
+        },
+        "mosgroen": {
+          "500": {
+            "$type": "color",
+            "$value": "oklch(56.062% 0.12413 112.04)"
+          },
+          "400": {
+            "$type": "color",
+            "$value": "oklch(66.98% 0.10134 108.86)"
+          },
+          "300": {
+            "$type": "color",
+            "$value": "oklch(73.556% 0.08332 107.25)"
+          },
+          "200": {
+            "$type": "color",
+            "$value": "oklch(80.149% 0.06364 105.82)"
+          },
+          "100": {
+            "$type": "color",
+            "$value": "oklch(86.756% 0.04296 104.52)"
+          },
+          "50": {
+            "$type": "color",
+            "$value": "oklch(93.373% 0.02168 103.35)"
+          }
+        },
+        "groen": {
+          "500": {
+            "$type": "color",
+            "$value": "oklch(55.24% 0.16526 137.86)"
+          },
+          "400": {
+            "$type": "color",
+            "$value": "oklch(66.346% 0.12903 135.38)"
+          },
+          "300": {
+            "$type": "color",
+            "$value": "oklch(73.043% 0.10443 134.33)"
+          },
+          "200": {
+            "$type": "color",
+            "$value": "oklch(79.76% 0.07885 133.47)"
+          },
+          "100": {
+            "$type": "color",
+            "$value": "oklch(86.493% 0.05277 132.76)"
+          },
+          "50": {
+            "$type": "color",
+            "$value": "oklch(93.241% 0.02644 132.14)"
+          }
+        },
+        "donkergroen": {
+          "500": {
+            "$type": "color",
+            "$value": "oklch(41.936% 0.07856 152.03)"
+          },
+          "400": {
+            "$type": "color",
+            "$value": "oklch(56.428% 0.05974 151.81)"
+          },
+          "300": {
+            "$type": "color",
+            "$value": "oklch(65.135% 0.04801 151.74)"
+          },
+          "200": {
+            "$type": "color",
+            "$value": "oklch(73.847% 0.03613 151.68)"
+          },
+          "100": {
+            "$type": "color",
+            "$value": "oklch(82.562% 0.02414 151.64)"
+          },
+          "50": {
+            "$type": "color",
+            "$value": "oklch(91.28% 0.01209 151.61)"
+          }
+        },
+        "bruin": {
+          "500": {
+            "$type": "color",
+            "$value": "oklch(56.785% 0.11349 86.368)"
+          },
+          "400": {
+            "$type": "color",
+            "$value": "oklch(67.528% 0.09509 85.232)"
+          },
+          "300": {
+            "$type": "color",
+            "$value": "oklch(73.998% 0.07915 84.192)"
+          },
+          "200": {
+            "$type": "color",
+            "$value": "oklch(80.483% 0.06112 83.087)"
+          },
+          "100": {
+            "$type": "color",
+            "$value": "oklch(86.98% 0.04166 81.989)"
+          },
+          "50": {
+            "$type": "color",
+            "$value": "oklch(93.486% 0.0212 80.933)"
+          }
+        },
+        "donkerbruin": {
+          "500": {
+            "$type": "color",
+            "$value": "oklch(38.627% 0.0777 34.12)"
+          },
+          "400": {
+            "$type": "color",
+            "$value": "oklch(53.953% 0.06019 35.078)"
+          },
+          "300": {
+            "$type": "color",
+            "$value": "oklch(63.158% 0.04877 35.25)"
+          },
+          "200": {
+            "$type": "color",
+            "$value": "oklch(72.366% 0.03694 35.32)"
+          },
+          "100": {
+            "$type": "color",
+            "$value": "oklch(81.576% 0.02482 35.341)"
+          },
+          "50": {
+            "$type": "color",
+            "$value": "oklch(90.787% 0.01249 35.338)"
+          }
+        },
+        "geel": {
+          "500": {
+            "$type": "color",
+            "$value": "oklch(90.176% 0.18368 101.29)"
+          },
+          "400": {
+            "$type": "color",
+            "$value": "oklch(92.563% 0.14814 99.544)"
+          },
+          "300": {
+            "$type": "color",
+            "$value": "oklch(94.016% 0.12252 98.338)"
+          },
+          "200": {
+            "$type": "color",
+            "$value": "oklch(95.486% 0.09442 97.023)"
+          },
+          "100": {
+            "$type": "color",
+            "$value": "oklch(96.973% 0.06436 95.605)"
+          },
+          "50": {
+            "$type": "color",
+            "$value": "oklch(98.478% 0.03278 94.095)"
+          }
+        },
+        "donkergeel": {
+          "500": {
+            "$type": "color",
+            "$value": "oklch(82.372% 0.1685 78.997)"
+          },
+          "400": {
+            "$type": "color",
+            "$value": "oklch(86.709% 0.13875 78.981)"
+          },
+          "300": {
+            "$type": "color",
+            "$value": "oklch(89.334% 0.11588 78.45)"
+          },
+          "200": {
+            "$type": "color",
+            "$value": "oklch(91.977% 0.09007 77.643)"
+          },
+          "100": {
+            "$type": "color",
+            "$value": "oklch(94.636% 0.06189 76.629)"
+          },
+          "50": {
+            "$type": "color",
+            "$value": "oklch(97.311% 0.03176 75.462)"
+          }
+        },
+        "oranje": {
+          "500": {
+            "$type": "color",
+            "$value": "oklch(66.559% 0.16914 52.908)"
+          },
+          "400": {
+            "$type": "color",
+            "$value": "oklch(74.841% 0.13908 55.833)"
+          },
+          "300": {
+            "$type": "color",
+            "$value": "oklch(79.84% 0.11609 56.375)"
+          },
+          "200": {
+            "$type": "color",
+            "$value": "oklch(84.859% 0.0902 56.4)"
+          },
+          "100": {
+            "$type": "color",
+            "$value": "oklch(89.893% 0.06198 56.102)"
+          },
+          "50": {
+            "$type": "color",
+            "$value": "oklch(94.941% 0.03181 55.608)"
+          }
+        },
+        "rood": {
+          "500": {
+            "$type": "color",
+            "$value": "oklch(56.705% 0.20669 29.543)"
+          },
+          "400": {
+            "$type": "color",
+            "$value": "oklch(67.452% 0.16094 32.878)"
+          },
+          "300": {
+            "$type": "color",
+            "$value": "oklch(73.934% 0.1314 33.835)"
+          },
+          "200": {
+            "$type": "color",
+            "$value": "oklch(80.433% 0.10038 34.365)"
+          },
+          "100": {
+            "$type": "color",
+            "$value": "oklch(86.947% 0.06804 34.631)"
+          },
+          "50": {
+            "$type": "color",
+            "$value": "oklch(93.47% 0.03454 34.732)"
+          }
+        },
+        "roze": {
+          "500": {
+            "$type": "color",
+            "$value": "oklch(77.485% 0.13385 342.44)"
+          },
+          "400": {
+            "$type": "color",
+            "$value": "oklch(83.097% 0.09965 342.38)"
+          },
+          "300": {
+            "$type": "color",
+            "$value": "oklch(86.47% 0.07939 342.35)"
+          },
+          "200": {
+            "$type": "color",
+            "$value": "oklch(89.847% 0.05931 342.32)"
+          },
+          "100": {
+            "$type": "color",
+            "$value": "oklch(93.228% 0.03939 342.29)"
+          },
+          "50": {
+            "$type": "color",
+            "$value": "oklch(96.613% 0.01962 342.26)"
+          }
+        },
+        "robijnrood": {
+          "500": {
+            "$type": "color",
+            "$value": "oklch(53.943% 0.21669 5.2)"
+          },
+          "400": {
+            "$type": "color",
+            "$value": "oklch(65.425% 0.1603 5.5584)"
+          },
+          "300": {
+            "$type": "color",
+            "$value": "oklch(72.328% 0.12739 5.7126)"
+          },
+          "200": {
+            "$type": "color",
+            "$value": "oklch(79.238% 0.09498 5.8376)"
+          },
+          "100": {
+            "$type": "color",
+            "$value": "oklch(86.154% 0.063 5.9412)"
+          },
+          "50": {
+            "$type": "color",
+            "$value": "oklch(93.075% 0.03136 6.0286)"
+          }
+        },
+        "lintblauw": {
+          "700": {
+            "$type": "color",
+            "$value": "oklch(28.03% 0.0577 258)",
+            "$description": "Originally rhc.color.primary.500 darkened (lch) by 0.4"
+          },
+          "600": {
+            "$type": "color",
+            "$value": "oklch(30.37% 0.0676 256.1)",
+            "$description": "Originally rhc.color.primary.500 darkened (lch) by 0.3"
+          },
+          "500": {
+            "$type": "color",
+            "$value": "oklch(37.619% 0.09695 253.44)"
+          },
+          "400": {
+            "$type": "color",
+            "$value": "oklch(53.169% 0.0691 261.16)"
+          },
+          "300": {
+            "$type": "color",
+            "$value": "oklch(62.52% 0.05436 263.59)"
+          },
+          "200": {
+            "$type": "color",
+            "$value": "oklch(71.882% 0.04026 265.26)"
+          },
+          "100": {
+            "$type": "color",
+            "$value": "oklch(81.25% 0.02657 266.47)"
+          },
+          "50": {
+            "$type": "color",
+            "$value": "oklch(90.623% 0.01318 267.39)"
+          }
+        },
+        "wit": {
+          "$type": "color",
+          "$value": "oklch(100% 0 0)"
+        },
+        "zwart": {
+          "$type": "color",
+          "$value": "oklch(0% 0 0)"
         },
         "transparent": {
           "$type": "color",
@@ -767,18 +1345,6 @@
   "common/color": {
     "rhc": {
       "color": {
-        "donkerblauw": {
-          "600": {
-            "$type": "color",
-            "$value": "#01496c",
-            "$description": "Originally rhc.color.donkerblauw.500 darkened (srgb) with modify by 0.3"
-          },
-          "700": {
-            "$type": "color",
-            "$value": "#163f5b",
-            "$description": "Originally rhc.color.donkerblauw.500 darkened (lch) by 0.4"
-          }
-        },
         "foreground": {
           "default": {
             "$type": "color",
@@ -894,13 +1460,11 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "#162f50",
-            "$description": "Originally rhc.color.primary.500 darkened (lch) by 0.3"
+            "$value": "{rhc.color.lintblauw.600}"
           },
           "active": {
             "$type": "color",
-            "$value": "#162945",
-            "$description": "Originally rhc.color.primary.500 darkened (lch) by 0.4"
+            "$value": "{rhc.color.lintblauw.700}"
           }
         }
       }
@@ -4480,8 +5044,7 @@
         "active": {
           "color": {
             "$type": "color",
-            "$value": "#1A4972",
-            "$description": "Originally rhc.color.hemelblauw.500 darkened (lch) with modify by 0.4"
+            "$value": "{rhc.color.hemelblauw.700}"
           }
         },
         "disabled": {
@@ -8562,7 +9125,8 @@
       "$figmaStyleReferences": {},
       "selectedTokenSets": {
         "brand/border": "enabled",
-        "brand/color": "enabled",
+        "brand/color": "disabled",
+        "brand/color-oklch": "enabled",
         "brand/size": "enabled",
         "brand/space": "enabled",
         "common/border": "enabled",
@@ -8653,7 +9217,8 @@
       "$figmaStyleReferences": {},
       "selectedTokenSets": {
         "brand/border": "enabled",
-        "brand/color": "enabled",
+        "brand/color": "disabled",
+        "brand/color-oklch": "enabled",
         "brand/size": "enabled",
         "brand/space": "enabled",
         "common/border": "enabled",
@@ -8745,7 +9310,8 @@
       "$figmaStyleReferences": {},
       "selectedTokenSets": {
         "brand/border": "enabled",
-        "brand/color": "enabled",
+        "brand/color": "disabled",
+        "brand/color-oklch": "enabled",
         "brand/size": "enabled",
         "brand/space": "enabled",
         "common/border": "enabled",
@@ -8838,7 +9404,8 @@
       "$figmaStyleReferences": {},
       "selectedTokenSets": {
         "brand/border": "enabled",
-        "brand/color": "enabled",
+        "brand/color": "disabled",
+        "brand/color-oklch": "enabled",
         "brand/size": "enabled",
         "brand/space": "enabled",
         "common/border": "enabled",
@@ -8931,7 +9498,8 @@
       "$figmaStyleReferences": {},
       "selectedTokenSets": {
         "brand/border": "enabled",
-        "brand/color": "enabled",
+        "brand/color": "disabled",
+        "brand/color-oklch": "enabled",
         "brand/size": "enabled",
         "brand/space": "enabled",
         "common/border": "enabled",
@@ -9026,7 +9594,8 @@
       "$figmaStyleReferences": {},
       "selectedTokenSets": {
         "brand/border": "enabled",
-        "brand/color": "enabled",
+        "brand/color": "disabled",
+        "brand/color-oklch": "enabled",
         "brand/size": "enabled",
         "brand/space": "enabled",
         "common/border": "enabled",
@@ -9119,7 +9688,8 @@
       "$figmaStyleReferences": {},
       "selectedTokenSets": {
         "brand/border": "enabled",
-        "brand/color": "enabled",
+        "brand/color": "disabled",
+        "brand/color-oklch": "enabled",
         "brand/size": "enabled",
         "brand/space": "enabled",
         "common/border": "enabled",
@@ -9211,6 +9781,7 @@
     "tokenSetOrder": [
       "brand/border",
       "brand/color",
+      "brand/color-oklch",
       "brand/space",
       "brand/size",
       "brand/text",

--- a/proprietary/design-tokens/src/color-oklch.css
+++ b/proprietary/design-tokens/src/color-oklch.css
@@ -1,0 +1,161 @@
+.rhc-theme--fixed-hue {
+  --rhc-color-cool-grey-hue: 264.364;
+  --rhc-color-lichtblauw-hue: 230.01;
+  --rhc-color-violet-hue: 355.91;
+  --rhc-color-paars-hue: 308.6;
+  --rhc-color-hemelblauw-hue: 246.59;
+  --rhc-color-donkerblauw-hue: 240.39;
+  --rhc-color-mintgroen-hue: 171.97;
+  --rhc-color-mosgroen-hue: 112.04;
+  --rhc-color-groen-hue: 137.86;
+  --rhc-color-donkergroen-hue: 152.03;
+  --rhc-color-bruin-hue: 86.368;
+  --rhc-color-donkerbruin-hue: 34.12;
+  --rhc-color-geel-hue: 101.29;
+  --rhc-color-donkergeel-hue: 78.997;
+  --rhc-color-oranje-hue: 52.908;
+  --rhc-color-rood-hue: 29.543;
+  --rhc-color-roze-hue: 342.44;
+  --rhc-color-robijnrood-hue: 5.2;
+  --rhc-color-lintblauw-hue: 253.44;
+}
+
+.rhc-theme {
+  --rhc-color-cool-grey-50: oklch(98.4% 0.003 var(--rhc-color-cool-grey-hue, 247.858));
+  --rhc-color-cool-grey-100: oklch(96.8% 0.007 var(--rhc-color-cool-grey-hue, 247.896));
+  --rhc-color-cool-grey-200: oklch(92.9% 0.013 var(--rhc-color-cool-grey-hue, 255.508));
+  --rhc-color-cool-grey-300: oklch(86.9% 0.022 var(--rhc-color-cool-grey-hue, 252.894));
+  --rhc-color-cool-grey-400: oklch(70.4% 0.04 var(--rhc-color-cool-grey-hue, 256.788));
+  --rhc-color-cool-grey-500: oklch(55.1% 0.027 var(--rhc-color-cool-grey-hue, 264.364));
+  --rhc-color-cool-grey-600: oklch(44.6% 0.043 var(--rhc-color-cool-grey-hue, 257.281));
+  --rhc-color-cool-grey-700: oklch(37.2% 0.044 var(--rhc-color-cool-grey-hue, 257.287));
+  --rhc-color-cool-grey-800: oklch(27.9% 0.041 var(--rhc-color-cool-grey-hue, 260.031));
+  --rhc-color-cool-grey-900: oklch(20.8% 0.042 var(--rhc-color-cool-grey-hue, 265.755));
+  --rhc-color-lichtblauw-50: oklch(97.13% 0.01044 var(--rhc-color-lichtblauw-hue, 231.63));
+  --rhc-color-lichtblauw-100: oklch(94.26% 0.02104 var(--rhc-color-lichtblauw-hue, 231.42));
+  --rhc-color-lichtblauw-200: oklch(91.392% 0.03181 var(--rhc-color-lichtblauw-hue, 231.19));
+  --rhc-color-lichtblauw-300: oklch(88.524% 0.04276 var(--rhc-color-lichtblauw-hue, 230.92));
+  --rhc-color-lichtblauw-400: oklch(85.658% 0.05394 var(--rhc-color-lichtblauw-hue, 230.62));
+  --rhc-color-lichtblauw-500: oklch(80.882% 0.07312 var(--rhc-color-lichtblauw-hue, 230.01));
+  --rhc-color-violet-50: oklch(92.167% 0.02788 var(--rhc-color-violet-hue, 355.89));
+  --rhc-color-violet-100: oklch(84.339% 0.05612 var(--rhc-color-violet-hue, 355.9));
+  --rhc-color-violet-200: oklch(76.516% 0.08481 var(--rhc-color-violet-hue, 355.91));
+  --rhc-color-violet-300: oklch(68.7% 0.11406 var(--rhc-color-violet-hue, 355.91));
+  --rhc-color-violet-400: oklch(60.893% 0.14403 var(--rhc-color-violet-hue, 355.92));
+  --rhc-color-violet-500: oklch(47.91% 0.19619 var(--rhc-color-violet-hue, 355.91));
+  --rhc-color-paars-50: oklch(89.553% 0.02007 var(--rhc-color-paars-hue, 315.24));
+  --rhc-color-paars-100: oklch(79.114% 0.04013 var(--rhc-color-paars-hue, 314.83));
+  --rhc-color-paars-200: oklch(68.687% 0.06012 var(--rhc-color-paars-hue, 314.28));
+  --rhc-color-paars-300: oklch(58.278% 0.07991 var(--rhc-color-paars-hue, 313.54));
+  --rhc-color-paars-400: oklch(47.901% 0.09917 var(--rhc-color-paars-hue, 312.44));
+  --rhc-color-paars-500: oklch(30.782% 0.12693 var(--rhc-color-paars-hue, 308.6));
+  --rhc-color-hemelblauw-50: oklch(93.47% 0.01956 var(--rhc-color-hemelblauw-hue, 259.24));
+  --rhc-color-hemelblauw-100: oklch(86.946% 0.03966 var(--rhc-color-hemelblauw-hue, 258.06));
+  --rhc-color-hemelblauw-200: oklch(80.43% 0.06043 var(--rhc-color-hemelblauw-hue, 256.6));
+  --rhc-color-hemelblauw-300: oklch(73.922% 0.08205 var(--rhc-color-hemelblauw-hue, 254.75));
+  --rhc-color-hemelblauw-400: oklch(67.426% 0.10487 var(--rhc-color-hemelblauw-hue, 252.37));
+  --rhc-color-hemelblauw-500: oklch(56.621% 0.1475 var(--rhc-color-hemelblauw-hue, 246.59));
+  --rhc-color-hemelblauw-700: oklch(
+    39.49% 0.086 var(--rhc-color-hemelblauw-hue, 248.3)
+  ); /** Originally rhc.color.hemelblauw.500 darkened (lch) with modify by 0.4 */
+
+  --rhc-color-donkerblauw-50: oklch(92.393% 0.01496 var(--rhc-color-donkerblauw-hue, 249.73));
+  --rhc-color-donkerblauw-100: oklch(84.789% 0.03031 var(--rhc-color-donkerblauw-hue, 248.96));
+  --rhc-color-donkerblauw-200: oklch(77.189% 0.04617 var(--rhc-color-donkerblauw-hue, 247.98));
+  --rhc-color-donkerblauw-300: oklch(69.594% 0.06272 var(--rhc-color-donkerblauw-hue, 246.69));
+  --rhc-color-donkerblauw-400: oklch(62.004% 0.08026 var(--rhc-color-donkerblauw-hue, 244.97));
+  --rhc-color-donkerblauw-500: oklch(49.37% 0.11351 var(--rhc-color-donkerblauw-hue, 240.39));
+  --rhc-color-donkerblauw-600: oklch(
+    38.54% 0.0857 var(--rhc-color-donkerblauw-hue, 238.6)
+  ); /** Originally rhc.color.donkerblauw.500 darkened (srgb) with modify by 0.3 */
+
+  --rhc-color-donkerblauw-700: oklch(
+    35.32% 0.0666 var(--rhc-color-donkerblauw-hue, 242.1)
+  ); /** Originally rhc.color.donkerblauw.500 darkened (lch) by 0.4 */
+
+  --rhc-color-mintgroen-50: oklch(96.974% 0.01502 var(--rhc-color-mintgroen-hue, 172.1));
+  --rhc-color-mintgroen-100: oklch(93.949% 0.02995 var(--rhc-color-mintgroen-hue, 172.08));
+  --rhc-color-mintgroen-200: oklch(90.925% 0.04475 var(--rhc-color-mintgroen-hue, 172.06));
+  --rhc-color-mintgroen-300: oklch(87.904% 0.05943 var(--rhc-color-mintgroen-hue, 172.04));
+  --rhc-color-mintgroen-400: oklch(84.884% 0.07397 var(--rhc-color-mintgroen-hue, 172.02));
+  --rhc-color-mintgroen-500: oklch(79.855% 0.0978 var(--rhc-color-mintgroen-hue, 171.97));
+  --rhc-color-mosgroen-50: oklch(93.373% 0.02168 var(--rhc-color-mosgroen-hue, 103.35));
+  --rhc-color-mosgroen-100: oklch(86.756% 0.04296 var(--rhc-color-mosgroen-hue, 104.52));
+  --rhc-color-mosgroen-200: oklch(80.149% 0.06364 var(--rhc-color-mosgroen-hue, 105.82));
+  --rhc-color-mosgroen-300: oklch(73.556% 0.08332 var(--rhc-color-mosgroen-hue, 107.25));
+  --rhc-color-mosgroen-400: oklch(66.98% 0.10134 var(--rhc-color-mosgroen-hue, 108.86));
+  --rhc-color-mosgroen-500: oklch(56.062% 0.12413 var(--rhc-color-mosgroen-hue, 112.04));
+  --rhc-color-groen-50: oklch(93.241% 0.02644 var(--rhc-color-groen-hue, 132.14));
+  --rhc-color-groen-100: oklch(86.493% 0.05277 var(--rhc-color-groen-hue, 132.76));
+  --rhc-color-groen-200: oklch(79.76% 0.07885 var(--rhc-color-groen-hue, 133.47));
+  --rhc-color-groen-300: oklch(73.043% 0.10443 var(--rhc-color-groen-hue, 134.33));
+  --rhc-color-groen-400: oklch(66.346% 0.12903 var(--rhc-color-groen-hue, 135.38));
+  --rhc-color-groen-500: oklch(55.24% 0.16526 var(--rhc-color-groen-hue, 137.86));
+  --rhc-color-donkergroen-50: oklch(91.28% 0.01209 var(--rhc-color-donkergroen-hue, 151.61));
+  --rhc-color-donkergroen-100: oklch(82.562% 0.02414 var(--rhc-color-donkergroen-hue, 151.64));
+  --rhc-color-donkergroen-200: oklch(73.847% 0.03613 var(--rhc-color-donkergroen-hue, 151.68));
+  --rhc-color-donkergroen-300: oklch(65.135% 0.04801 var(--rhc-color-donkergroen-hue, 151.74));
+  --rhc-color-donkergroen-400: oklch(56.428% 0.05974 var(--rhc-color-donkergroen-hue, 151.81));
+  --rhc-color-donkergroen-500: oklch(41.936% 0.07856 var(--rhc-color-donkergroen-hue, 152.03));
+  --rhc-color-bruin-50: oklch(93.486% 0.0212 var(--rhc-color-bruin-hue, 80.933));
+  --rhc-color-bruin-100: oklch(86.98% 0.04166 var(--rhc-color-bruin-hue, 81.989));
+  --rhc-color-bruin-200: oklch(80.483% 0.06112 var(--rhc-color-bruin-hue, 83.087));
+  --rhc-color-bruin-300: oklch(73.998% 0.07915 var(--rhc-color-bruin-hue, 84.192));
+  --rhc-color-bruin-400: oklch(67.528% 0.09509 var(--rhc-color-bruin-hue, 85.232));
+  --rhc-color-bruin-500: oklch(56.785% 0.11349 var(--rhc-color-bruin-hue, 86.368));
+  --rhc-color-donkerbruin-50: oklch(90.787% 0.01249 var(--rhc-color-donkerbruin-hue, 35.338));
+  --rhc-color-donkerbruin-100: oklch(81.576% 0.02482 var(--rhc-color-donkerbruin-hue, 35.341));
+  --rhc-color-donkerbruin-200: oklch(72.366% 0.03694 var(--rhc-color-donkerbruin-hue, 35.32));
+  --rhc-color-donkerbruin-300: oklch(63.158% 0.04877 var(--rhc-color-donkerbruin-hue, 35.25));
+  --rhc-color-donkerbruin-400: oklch(53.953% 0.06019 var(--rhc-color-donkerbruin-hue, 35.078));
+  --rhc-color-donkerbruin-500: oklch(38.627% 0.0777 var(--rhc-color-donkerbruin-hue, 34.12));
+  --rhc-color-geel-50: oklch(98.478% 0.03278 var(--rhc-color-geel-hue, 94.095));
+  --rhc-color-geel-100: oklch(96.973% 0.06436 var(--rhc-color-geel-hue, 95.605));
+  --rhc-color-geel-200: oklch(95.486% 0.09442 var(--rhc-color-geel-hue, 97.023));
+  --rhc-color-geel-300: oklch(94.016% 0.12252 var(--rhc-color-geel-hue, 98.338));
+  --rhc-color-geel-400: oklch(92.563% 0.14814 var(--rhc-color-geel-hue, 99.544));
+  --rhc-color-geel-500: oklch(90.176% 0.18368 var(--rhc-color-geel-hue, 101.29));
+  --rhc-color-donkergeel-50: oklch(97.311% 0.03176 var(--rhc-color-donkergeel-hue, 75.462));
+  --rhc-color-donkergeel-100: oklch(94.636% 0.06189 var(--rhc-color-donkergeel-hue, 76.629));
+  --rhc-color-donkergeel-200: oklch(91.977% 0.09007 var(--rhc-color-donkergeel-hue, 77.643));
+  --rhc-color-donkergeel-300: oklch(89.334% 0.11588 var(--rhc-color-donkergeel-hue, 78.45));
+  --rhc-color-donkergeel-400: oklch(86.709% 0.13875 var(--rhc-color-donkergeel-hue, 78.981));
+  --rhc-color-donkergeel-500: oklch(82.372% 0.1685 var(--rhc-color-donkergeel-hue, 78.997));
+  --rhc-color-oranje-50: oklch(94.941% 0.03181 var(--rhc-color-oranje-hue, 55.608));
+  --rhc-color-oranje-100: oklch(89.893% 0.06198 var(--rhc-color-oranje-hue, 56.102));
+  --rhc-color-oranje-200: oklch(84.859% 0.0902 var(--rhc-color-oranje-hue, 56.4));
+  --rhc-color-oranje-300: oklch(79.84% 0.11609 var(--rhc-color-oranje-hue, 56.375));
+  --rhc-color-oranje-400: oklch(74.841% 0.13908 var(--rhc-color-oranje-hue, 55.833));
+  --rhc-color-oranje-500: oklch(66.559% 0.16914 var(--rhc-color-oranje-hue, 52.908));
+  --rhc-color-rood-50: oklch(93.47% 0.03454 var(--rhc-color-rood-hue, 34.732));
+  --rhc-color-rood-100: oklch(86.947% 0.06804 var(--rhc-color-rood-hue, 34.631));
+  --rhc-color-rood-200: oklch(80.433% 0.10038 var(--rhc-color-rood-hue, 34.365));
+  --rhc-color-rood-300: oklch(73.934% 0.1314 var(--rhc-color-rood-hue, 33.835));
+  --rhc-color-rood-400: oklch(67.452% 0.16094 var(--rhc-color-rood-hue, 32.878));
+  --rhc-color-rood-500: oklch(56.705% 0.20669 var(--rhc-color-rood-hue, 29.543));
+  --rhc-color-roze-50: oklch(96.613% 0.01962 var(--rhc-color-roze-hue, 342.26));
+  --rhc-color-roze-100: oklch(93.228% 0.03939 var(--rhc-color-roze-hue, 342.29));
+  --rhc-color-roze-200: oklch(89.847% 0.05931 var(--rhc-color-roze-hue, 342.32));
+  --rhc-color-roze-300: oklch(86.47% 0.07939 var(--rhc-color-roze-hue, 342.35));
+  --rhc-color-roze-400: oklch(83.097% 0.09965 var(--rhc-color-roze-hue, 342.38));
+  --rhc-color-roze-500: oklch(77.485% 0.13385 var(--rhc-color-roze-hue, 342.44));
+  --rhc-color-robijnrood-50: oklch(93.075% 0.03136 var(--rhc-color-robijnrood-hue, 6.0286));
+  --rhc-color-robijnrood-100: oklch(86.154% 0.063 var(--rhc-color-robijnrood-hue, 5.9412));
+  --rhc-color-robijnrood-200: oklch(79.238% 0.09498 var(--rhc-color-robijnrood-hue, 5.8376));
+  --rhc-color-robijnrood-300: oklch(72.328% 0.12739 var(--rhc-color-robijnrood-hue, 5.7126));
+  --rhc-color-robijnrood-400: oklch(65.425% 0.1603 var(--rhc-color-robijnrood-hue, 5.5584));
+  --rhc-color-robijnrood-500: oklch(53.943% 0.21669 var(--rhc-color-robijnrood-hue, 5.2));
+  --rhc-color-lintblauw-50: oklch(90.623% 0.01318 var(--rhc-color-lintblauw-hue, 267.39));
+  --rhc-color-lintblauw-100: oklch(81.25% 0.02657 var(--rhc-color-lintblauw-hue, 266.47));
+  --rhc-color-lintblauw-200: oklch(71.882% 0.04026 var(--rhc-color-lintblauw-hue, 265.26));
+  --rhc-color-lintblauw-300: oklch(62.52% 0.05436 var(--rhc-color-lintblauw-hue, 263.59));
+  --rhc-color-lintblauw-400: oklch(53.169% 0.0691 var(--rhc-color-lintblauw-hue, 261.16));
+  --rhc-color-lintblauw-500: oklch(37.619% 0.09695 var(--rhc-color-lintblauw-hue, 253.44));
+  --rhc-color-lintblauw-600: oklch(
+    30.37% 0.0676 var(--rhc-color-lintblauw-hue, 256.1)
+  ); /** Originally rhc.color.primary.500 darkened (lch) by 0.3 */
+
+  --rhc-color-lintblauw-700: oklch(
+    28.03% 0.0577 var(--rhc-color-lintblauw-hue, 258)
+  ); /** Originally rhc.color.primary.500 darkened (lch) by 0.4 */
+}


### PR DESCRIPTION
Color tints and shades now have the same hue as the base color, using `rhc-theme--fixed-hue`.

Wondering if Chromatic will detect color differences all over the place, and if they are perceptible.

Update: looks good in Chromatic! Color differences are not perceptible according to their measurements, whatever they are.

We should probably make some more pages in Storybook for the other color schemes before we merge.