### PR TITLE
refactor: oklch instead of hex colors

### DIFF
--- a/.changeset/test-bar-quux.md
+++ b/.changeset/test-bar-quux.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/design-tokens': patch
+---
+
+CSS now uses `oklch()` colors instead of hex-colors.

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -33,520 +33,520 @@
         "cool-grey": {
           "50": {
             "$type": "color",
-            "$value": "#F8FAFC"
+            "$value": "oklch(98.415% 0.00341 247.86)"
           },
           "100": {
             "$type": "color",
-            "$value": "#F1F5F9"
+            "$value": "oklch(96.826% 0.00685 247.9)"
           },
           "200": {
             "$type": "color",
-            "$value": "#E2E8F0"
+            "$value": "oklch(92.876% 0.01262 255.51)"
           },
           "300": {
             "$type": "color",
-            "$value": "#CBD5E1"
+            "$value": "oklch(86.898% 0.01985 252.89)"
           },
           "400": {
             "$type": "color",
-            "$value": "#94A3B8"
+            "$value": "oklch(71.067% 0.03511 256.79)"
           },
           "500": {
             "$type": "color",
-            "$value": "#64748B"
+            "$value": "oklch(55.439% 0.04072 257.42)"
           },
           "600": {
             "$type": "color",
-            "$value": "#475569"
+            "$value": "oklch(44.553% 0.03745 257.28)"
           },
           "700": {
             "$type": "color",
-            "$value": "#334155"
+            "$value": "oklch(37.17% 0.03916 257.29)"
           },
           "800": {
             "$type": "color",
-            "$value": "#1E293B"
+            "$value": "oklch(27.95% 0.03685 260.03)"
           },
           "900": {
             "$type": "color",
-            "$value": "#0F172A"
+            "$value": "oklch(20.768% 0.03982 265.75)"
           }
         },
         "lichtblauw": {
           "50": {
             "$type": "color",
-            "$value": "#eef7fb"
+            "$value": "oklch(97.054% 0.01097 225.98)"
           },
           "100": {
             "$type": "color",
-            "$value": "#ddeff8"
+            "$value": "oklch(94.147% 0.02265 229.08)"
           },
           "200": {
             "$type": "color",
-            "$value": "#CCE7F4"
+            "$value": "oklch(91.223% 0.03362 228.33)"
           },
           "300": {
             "$type": "color",
-            "$value": "#BCDFF0"
+            "$value": "oklch(88.38% 0.04367 228.77)"
           },
           "400": {
             "$type": "color",
-            "$value": "#ABD7ED"
+            "$value": "oklch(85.523% 0.05526 229.82)"
           },
           "500": {
             "$type": "color",
-            "$value": "#8fcae7"
+            "$value": "oklch(80.882% 0.07312 230.01)"
           }
         },
         "violet": {
           "50": {
             "$type": "color",
-            "$value": "#f2d9e7"
+            "$value": "oklch(90.978% 0.03308 342.99)"
           },
           "100": {
             "$type": "color",
-            "$value": "#e5b3d0"
+            "$value": "oklch(82.032% 0.06897 343.04)"
           },
           "200": {
             "$type": "color",
-            "$value": "#D88CB7"
+            "$value": "oklch(73.02% 0.10691 345.11)"
           },
           "300": {
             "$type": "color",
-            "$value": "#CB66A0"
+            "$value": "oklch(64.657% 0.14449 346.37)"
           },
           "400": {
             "$type": "color",
-            "$value": "#BE4088"
+            "$value": "oklch(57.059% 0.17678 348.88)"
           },
           "500": {
             "$type": "color",
-            "$value": "#a90061"
+            "$value": "oklch(47.91% 0.19619 355.91)"
           }
         },
         "paars": {
           "50": {
             "$type": "color",
-            "$value": "#e3dce7"
+            "$value": "oklch(90.322% 0.01659 313.61)"
           },
           "100": {
             "$type": "color",
-            "$value": "#c6b9cf"
+            "$value": "oklch(80.331% 0.03366 311.69)"
           },
           "200": {
             "$type": "color",
-            "$value": "#A995B7"
+            "$value": "oklch(69.878% 0.0537 311.31)"
           },
           "300": {
             "$type": "color",
-            "$value": "#8D729F"
+            "$value": "oklch(59.433% 0.07379 311.43)"
           },
           "400": {
             "$type": "color",
-            "$value": "#714f87"
+            "$value": "oklch(48.725% 0.0951 311.16)"
           },
           "500": {
             "$type": "color",
-            "$value": "#42145f"
+            "$value": "oklch(30.782% 0.12693 308.6)"
           }
         },
         "hemelblauw": {
           "50": {
             "$type": "color",
-            "$value": "#d9ebf7"
+            "$value": "oklch(93.03% 0.02517 236.84)"
           },
           "100": {
             "$type": "color",
-            "$value": "#b3d7ee"
+            "$value": "oklch(86.064% 0.04976 236.19)"
           },
           "200": {
             "$type": "color",
-            "$value": "#8CC3E6"
+            "$value": "oklch(79.159% 0.07586 236.92)"
           },
           "300": {
             "$type": "color",
-            "$value": "#66AFDD"
+            "$value": "oklch(72.44% 0.09931 237.91)"
           },
           "400": {
             "$type": "color",
-            "$value": "#409CD5"
+            "$value": "oklch(66.267% 0.12087 239.6)"
           },
           "500": {
             "$type": "color",
-            "$value": "#007bc7"
+            "$value": "oklch(56.621% 0.1475 246.59)"
           }
         },
         "donkerblauw": {
           "50": {
             "$type": "color",
-            "$value": "#d9e8f0"
+            "$value": "oklch(92.214% 0.01939 230.71)"
           },
           "100": {
             "$type": "color",
-            "$value": "#b3d2e1"
+            "$value": "oklch(84.583% 0.03915 228.62)"
           },
           "200": {
             "$type": "color",
-            "$value": "#8CBBD2"
+            "$value": "oklch(76.667% 0.05961 229.57)"
           },
           "300": {
             "$type": "color",
-            "$value": "#66A4C3"
+            "$value": "oklch(68.848% 0.07861 231.2)"
           },
           "400": {
             "$type": "color",
-            "$value": "#408EB4"
+            "$value": "oklch(61.393% 0.09536 232.46)"
           },
           "500": {
             "$type": "color",
-            "$value": "#01689b"
+            "$value": "oklch(49.37% 0.11351 240.39)"
           }
         },
         "mintgroen": {
           "50": {
             "$type": "color",
-            "$value": "#eaf8f4"
+            "$value": "oklch(96.762% 0.01565 177.09)"
           },
           "100": {
             "$type": "color",
-            "$value": "#d6f2e9"
+            "$value": "oklch(93.832% 0.03166 174.3)"
           },
           "200": {
             "$type": "color",
-            "$value": "#C1EBDE"
+            "$value": "oklch(90.671% 0.04698 174.46)"
           },
           "300": {
             "$type": "color",
-            "$value": "#ACE4D3"
+            "$value": "oklch(87.562% 0.06195 174.17)"
           },
           "400": {
             "$type": "color",
-            "$value": "#98DDC8"
+            "$value": "oklch(84.568% 0.07554 173.42)"
           },
           "500": {
             "$type": "color",
-            "$value": "#76d2b6"
+            "$value": "oklch(79.855% 0.0978 171.97)"
           }
         },
         "mosgroen": {
           "50": {
             "$type": "color",
-            "$value": "#ebebd9"
+            "$value": "oklch(93.522% 0.02386 106.85)"
           },
           "100": {
             "$type": "color",
-            "$value": "#d6d7b3"
+            "$value": "oklch(86.906% 0.048 108.67)"
           },
           "200": {
             "$type": "color",
-            "$value": "#C1C38C"
+            "$value": "oklch(80.213% 0.07319 109.69)"
           },
           "300": {
             "$type": "color",
-            "$value": "#ADAF66"
+            "$value": "oklch(73.58% 0.09559 109.9)"
           },
           "400": {
             "$type": "color",
-            "$value": "#999C40"
+            "$value": "oklch(67.146% 0.1152 110.87)"
           },
           "500": {
             "$type": "color",
-            "$value": "#777b00"
+            "$value": "oklch(56.062% 0.12413 112.04)"
           }
         },
         "groen": {
           "50": {
             "$type": "color",
-            "$value": "#e1eddb"
+            "$value": "oklch(93.217% 0.02714 134.97)"
           },
           "100": {
             "$type": "color",
-            "$value": "#c4dbb6"
+            "$value": "oklch(86.449% 0.05573 133.62)"
           },
           "200": {
             "$type": "color",
-            "$value": "#A5C991"
+            "$value": "oklch(79.53% 0.08581 134.66)"
           },
           "300": {
             "$type": "color",
-            "$value": "#88B76D"
+            "$value": "oklch(72.789% 0.11337 134.83)"
           },
           "400": {
             "$type": "color",
-            "$value": "#6AA549"
+            "$value": "oklch(66.05% 0.13931 135.66)"
           },
           "500": {
             "$type": "color",
-            "$value": "#39870c"
+            "$value": "oklch(55.24% 0.16526 137.86)"
           }
         },
         "donkergroen": {
           "50": {
             "$type": "color",
-            "$value": "#dfe6e1"
+            "$value": "oklch(91.82% 0.01004 155.08)"
           },
           "100": {
             "$type": "color",
-            "$value": "#becdc3"
+            "$value": "oklch(83.4% 0.02133 156.74)"
           },
           "200": {
             "$type": "color",
-            "$value": "#9DB4A4"
+            "$value": "oklch(74.772% 0.03405 155.14)"
           },
           "300": {
             "$type": "color",
-            "$value": "#7D9B87"
+            "$value": "oklch(66.075% 0.04465 155.81)"
           },
           "400": {
             "$type": "color",
-            "$value": "#5D8269"
+            "$value": "oklch(57.134% 0.05672 154.7)"
           },
           "500": {
             "$type": "color",
-            "$value": "#275937"
+            "$value": "oklch(41.936% 0.07856 152.03)"
           }
         },
         "bruin": {
           "50": {
             "$type": "color",
-            "$value": "#efeada"
+            "$value": "oklch(93.663% 0.02192 92.512)"
           },
           "100": {
             "$type": "color",
-            "$value": "#dfd4b6"
+            "$value": "oklch(87.1% 0.04183 90.262)"
           },
           "200": {
             "$type": "color",
-            "$value": "#CFBF90"
+            "$value": "oklch(80.647% 0.06495 91.487)"
           },
           "300": {
             "$type": "color",
-            "$value": "#BFA96C"
+            "$value": "oklch(73.999% 0.08378 90.368)"
           },
           "400": {
             "$type": "color",
-            "$value": "#AF9447"
+            "$value": "oklch(67.529% 0.10169 90.165)"
           },
           "500": {
             "$type": "color",
-            "$value": "#94710a"
+            "$value": "oklch(56.785% 0.11349 86.368)"
           }
         },
         "donkerbruin": {
           "50": {
             "$type": "color",
-            "$value": "#e8e0df"
+            "$value": "oklch(91.272% 0.00886 26.023)"
           },
           "100": {
             "$type": "color",
-            "$value": "#d1c2be"
+            "$value": "oklch(82.53% 0.01789 35.341)"
           },
           "200": {
             "$type": "color",
-            "$value": "#BAA39D"
+            "$value": "oklch(73.385% 0.02847 34.982)"
           },
           "300": {
             "$type": "color",
-            "$value": "#A3847D"
+            "$value": "oklch(64.043% 0.0397 32.893)"
           },
           "400": {
             "$type": "color",
-            "$value": "#8D665D"
+            "$value": "oklch(54.784% 0.05269 33.378)"
           },
           "500": {
             "$type": "color",
-            "$value": "#673327"
+            "$value": "oklch(38.627% 0.0777 34.12)"
           }
         },
         "geel": {
           "50": {
             "$type": "color",
-            "$value": "#fefbdd"
+            "$value": "oklch(98.264% 0.03916 102.41)"
           },
           "100": {
             "$type": "color",
-            "$value": "#fdf6bc"
+            "$value": "oklch(96.474% 0.07444 101.91)"
           },
           "200": {
             "$type": "color",
-            "$value": "#FCF199"
+            "$value": "oklch(94.767% 0.10943 102.07)"
           },
           "300": {
             "$type": "color",
-            "$value": "#FBED78"
+            "$value": "oklch(93.421% 0.13889 102.52)"
           },
           "400": {
             "$type": "color",
-            "$value": "#FAE856"
+            "$value": "oklch(91.982% 0.16222 102.24)"
           },
           "500": {
             "$type": "color",
-            "$value": "#f9e11e"
+            "$value": "oklch(90.176% 0.18368 101.29)"
           }
         },
         "donkergeel": {
           "50": {
             "$type": "color",
-            "$value": "#fff4db"
+            "$value": "oklch(96.925% 0.0348 87.074)"
           },
           "100": {
             "$type": "color",
-            "$value": "#ffe9b8"
+            "$value": "oklch(93.996% 0.06747 86.64)"
           },
           "200": {
             "$type": "color",
-            "$value": "#FDDE94"
+            "$value": "oklch(91.006% 0.0986 87.683)"
           },
           "300": {
             "$type": "color",
-            "$value": "#FDD370"
+            "$value": "oklch(88.343% 0.12671 86.692)"
           },
           "400": {
             "$type": "color",
-            "$value": "#FDC84D"
+            "$value": "oklch(85.857% 0.14832 84.924)"
           },
           "500": {
             "$type": "color",
-            "$value": "#ffb612"
+            "$value": "oklch(82.372% 0.1685 78.997)"
           }
         },
         "oranje": {
           "50": {
             "$type": "color",
-            "$value": "#fbead9"
+            "$value": "oklch(94.607% 0.02922 67.463)"
           },
           "100": {
             "$type": "color",
-            "$value": "#f6d4b3"
+            "$value": "oklch(89.031% 0.05798 66.118)"
           },
           "200": {
             "$type": "color",
-            "$value": "#F1BE8C"
+            "$value": "oklch(83.566% 0.08766 65.585)"
           },
           "300": {
             "$type": "color",
-            "$value": "#EDA966"
+            "$value": "oklch(78.604% 0.11599 64.327)"
           },
           "400": {
             "$type": "color",
-            "$value": "#E89440"
+            "$value": "oklch(73.791% 0.14021 62.24)"
           },
           "500": {
             "$type": "color",
-            "$value": "#e17000"
+            "$value": "oklch(66.559% 0.16914 52.908)"
           }
         },
         "rood": {
           "50": {
             "$type": "color",
-            "$value": "#f9dfdd"
+            "$value": "oklch(92.432% 0.02892 22.962)"
           },
           "100": {
             "$type": "color",
-            "$value": "#f2bfbc"
+            "$value": "oklch(84.913% 0.05903 22.29)"
           },
           "200": {
             "$type": "color",
-            "$value": "#EC9F99"
+            "$value": "oklch(77.654% 0.09297 24.341)"
           },
           "300": {
             "$type": "color",
-            "$value": "#E67F78"
+            "$value": "oklch(70.838% 0.12823 24.893)"
           },
           "400": {
             "$type": "color",
-            "$value": "#DF6056"
+            "$value": "oklch(64.638% 0.161 26.992)"
           },
           "500": {
             "$type": "color",
-            "$value": "#d52b1e"
+            "$value": "oklch(56.705% 0.20669 29.543)"
           }
         },
         "roze": {
           "50": {
             "$type": "color",
-            "$value": "#fdeff8"
+            "$value": "oklch(96.567% 0.01909 338.71)"
           },
           "100": {
             "$type": "color",
-            "$value": "#fbdef0"
+            "$value": "oklch(92.954% 0.03952 340.19)"
           },
           "200": {
             "$type": "color",
-            "$value": "#F8CEE8"
+            "$value": "oklch(89.486% 0.05785 340.73)"
           },
           "300": {
             "$type": "color",
-            "$value": "#F6BDE1"
+            "$value": "oklch(86.014% 0.07989 340.69)"
           },
           "400": {
             "$type": "color",
-            "$value": "#F4ADD9"
+            "$value": "oklch(82.767% 0.09974 341.81)"
           },
           "500": {
             "$type": "color",
-            "$value": "#f092cd"
+            "$value": "oklch(77.485% 0.13385 342.44)"
           }
         },
         "robijnrood": {
           "50": {
             "$type": "color",
-            "$value": "#f7d9e7"
+            "$value": "oklch(91.407% 0.0378 347.99)"
           },
           "100": {
             "$type": "color",
-            "$value": "#efb3ce"
+            "$value": "oklch(82.953% 0.07749 350.23)"
           },
           "200": {
             "$type": "color",
-            "$value": "#E78CB6"
+            "$value": "oklch(74.709% 0.12112 351.28)"
           },
           "300": {
             "$type": "color",
-            "$value": "#DF669D"
+            "$value": "oklch(67.241% 0.1616 353.85)"
           },
           "400": {
             "$type": "color",
-            "$value": "#D74085"
+            "$value": "oklch(60.869% 0.19588 356.71)"
           },
           "500": {
             "$type": "color",
-            "$value": "#ca005d"
+            "$value": "oklch(53.943% 0.21669 5.2)"
           }
         },
         "lintblauw": {
           "50": {
             "$type": "color",
-            "$value": "#dce3ea"
+            "$value": "oklch(91.254% 0.01217 247.96)"
           },
           "100": {
             "$type": "color",
-            "$value": "#b8c6d5"
+            "$value": "oklch(82.048% 0.02611 250)"
           },
           "200": {
             "$type": "color",
-            "$value": "#95a9c0"
+            "$value": "oklch(72.708% 0.04031 252.01)"
           },
           "300": {
             "$type": "color",
-            "$value": "#738eab"
+            "$value": "oklch(63.656% 0.05353 250.5)"
           },
           "400": {
             "$type": "color",
-            "$value": "#4f7196"
+            "$value": "oklch(53.819% 0.07031 251.25)"
           },
           "500": {
             "$type": "color",
-            "$value": "#154273"
+            "$value": "oklch(37.619% 0.09695 253.44)"
           }
         },
         "wit": {
           "$type": "color",
-          "$value": "#fff"
+          "$value": "oklch(100% 0 0)"
         },
         "zwart": {
           "$type": "color",
-          "$value": "#000"
+          "$value": "oklch(0% 0 0)"
         },
         "transparent": {
           "$type": "color",
@@ -770,12 +770,12 @@
         "donkerblauw": {
           "600": {
             "$type": "color",
-            "$value": "#01496c",
+            "$value": "oklch(38.54% 0.0857 238.6)",
             "$description": "Originally rhc.color.donkerblauw.500 darkened (srgb) with modify by 0.3"
           },
           "700": {
             "$type": "color",
-            "$value": "#163f5b",
+            "$value": "oklch(35.32% 0.0666 242.1)",
             "$description": "Originally rhc.color.donkerblauw.500 darkened (lch) by 0.4"
           }
         },
@@ -894,12 +894,12 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "#162f50",
+            "$value": "oklch(30.37% 0.0676 256.1)",
             "$description": "Originally rhc.color.primary.500 darkened (lch) by 0.3"
           },
           "active": {
             "$type": "color",
-            "$value": "#162945",
+            "$value": "oklch(28.03% 0.0577 258)",
             "$description": "Originally rhc.color.primary.500 darkened (lch) by 0.4"
           }
         }
@@ -4480,7 +4480,7 @@
         "active": {
           "color": {
             "$type": "color",
-            "$value": "#1A4972",
+            "$value": "oklch(39.49% 0.086 248.3)",
             "$description": "Originally rhc.color.hemelblauw.500 darkened (lch) with modify by 0.4"
           }
         },
@@ -6649,7 +6649,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "#0000001a"
+              "$value": "oklch(0% 0 none / 0.102)"
             }
           },
           "box-inline-start-shadow": {
@@ -6671,7 +6671,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "#0000001a"
+              "$value": "oklch(0% 0 none / 0.102)"
             }
           }
         },
@@ -7260,11 +7260,11 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "#2C5D12"
+            "$value": "oklch(42.78% 0.1169 137.2)"
           },
           "active": {
             "$type": "color",
-            "$value": "#275012"
+            "$value": "oklch(38.71% 0.1016 137.1)"
           }
         }
       }
@@ -7300,11 +7300,11 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "#1A5587"
+            "$value": "oklch(43.82% 0.1017 248.4)"
           },
           "active": {
             "$type": "color",
-            "$value": "#1A4972"
+            "$value": "oklch(39.49% 0.086 248.3)"
           }
         }
       }
@@ -7340,11 +7340,11 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "#528E7C"
+            "$value": "oklch(60.03% 0.0691 172.6)"
           },
           "active": {
             "$type": "color",
-            "$value": "#477869"
+            "$value": "oklch(60.03% 0.0691 172.6)"
           }
         }
       }
@@ -7380,11 +7380,11 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "#994E0E"
+            "$value": "oklch(50.69% 0.1215 53.6)"
           },
           "active": {
             "$type": "color",
-            "$value": "#82430F"
+            "$value": "oklch(45.34% 0.1055 53.92)"
           }
         }
       }
@@ -7420,11 +7420,11 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "#301243"
+            "$value": "oklch(25.58% 0.0909 309.6)"
           },
           "active": {
             "$type": "color",
-            "$value": "#2B113A"
+            "$value": "oklch(23.97% 0.0791 311.1)"
           }
         }
       }
@@ -7460,11 +7460,11 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "#8A1641"
+            "$value": "oklch(41.89% 0.1515 5.365)"
           },
           "active": {
             "$type": "color",
-            "$value": "#761838"
+            "$value": "oklch(38% 0.1293 5.781)"
           }
         }
       }
@@ -7500,11 +7500,11 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "#A2648A"
+            "$value": "oklch(58.32% 0.0943 343)"
           },
           "active": {
             "$type": "color",
-            "$value": "#895675"
+            "$value": "oklch(52.01% 0.0797 343.1)"
           }
         }
       }
@@ -7540,11 +7540,11 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "#741344"
+            "$value": "oklch(37.63% 0.1367 355.7)"
           },
           "active": {
             "$type": "color",
-            "$value": "#63143A"
+            "$value": "oklch(34.12% 0.1167 356.1)"
           }
         }
       }


### PR DESCRIPTION
Verbeterde versie van eerder PR, waar kleuren niet op de juiste manier naar OKLCH waren vertaald. Het kleurverschil met hex kleuren is nu opgelost. https://github.com/nl-design-system/rijkshuisstijl-community/pull/2348
