### PR TITLE
chore: upgrade handlebars to 4.7.9

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  handlebars@>=4.0.0 <4.7.9: '>=4.7.9'
   locutus@>=2.0.12 <2.0.39: '>=2.0.39'
   '@isaacs/brace-expansion@<=5.0.0': '>=5.0.1'
 
@@ -246,8 +247,6 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
-
-  apps/rhc-templates/dist/dev: {}
 
   packages/build-utils-css:
     devDependencies:
@@ -9812,8 +9811,8 @@ packages:
   handle-thing@2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
 
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
 
@@ -23084,7 +23083,7 @@ snapshots:
   conventional-changelog-writer@8.2.0:
     dependencies:
       conventional-commits-filter: 5.0.0
-      handlebars: 4.7.8
+      handlebars: 4.7.9
       meow: 13.2.0
       semver: 7.7.4
 
@@ -25138,7 +25137,7 @@ snapshots:
 
   handle-thing@2.0.1: {}
 
-  handlebars@4.7.8:
+  handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
       neo-async: 2.6.2
@@ -31512,7 +31511,7 @@ snapshots:
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.8
+      handlebars: 4.7.9
       jest: 30.2.0(@types/node@25.3.3)(esbuild-register@3.6.0(esbuild@0.27.4))
       json5: 2.2.3
       lodash.memoize: 4.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,6 +48,7 @@ auditConfig:
     - GHSA-vh9h-29pq-r5m8
 
 overrides:
+  handlebars@>=4.0.0 <4.7.9: ">=4.7.9"
   locutus@>=2.0.12 <2.0.39: ">=2.0.39"
   "@isaacs/brace-expansion@<=5.0.0": ">=5.0.1"
 


### PR DESCRIPTION
Handlebars is a transitive dependency of lerna-lite; overriding version because <4.7.8 has a vulnerability
