### PR TITLE
refactor: page layout cleanup

### DIFF
--- a/.changeset/stale-moose-wonder.md
+++ b/.changeset/stale-moose-wonder.md
@@ -1,0 +1,9 @@
+---
+'@rijkshuisstijl-community/components-react': patch
+'@rijkshuisstijl-community/components-css': patch
+'@rijkshuisstijl-community/components-angular': patch
+---
+
+Use new Utrecht Page Footer CSS that provides `utrecht-page-footer__content`, which replaces `rhc-page-footer__content`.
+
+Replace `rhc-page-footer__wrapper` new nested `rhc-page-footer-layout` div.

--- a/.changeset/thin-clouds-move.md
+++ b/.changeset/thin-clouds-move.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/design-tokens': minor
+---
+
+Add design tokens for `utrecht.page-footer.content.*`'.

--- a/packages/components-angular/src/footer/footer.component.html
+++ b/packages/components-angular/src/footer/footer.component.html
@@ -1,32 +1,36 @@
-@if (preFooter) {
-  <div class="rhc-page-prefooter">
-    @if (preFooterMessage) {
-      <span class="rhc-page-prefooter__content">{{ preFooterMessage }}</span>
-    }
-  </div>
-}
+<footer class="rhc-page-footer-container">
+  @if (preFooter) {
+    <div class="rhc-page-prefooter">
+      @if (preFooterMessage) {
+        <span class="rhc-page-prefooter__content">{{ preFooterMessage }}</span>
+      }
+    </div>
+  }
 
-<footer [class]="`utrecht-page-footer rhc-page-footer ${backgroundClass}`">
-  <div class="utrecht-page-footer__content">
-    <div class="rhc-page-footer-layout">
-      @if (heading) {
-        <h2 aria-hidden="true" hidden>{{ heading }}</h2>
-      }
-      @if (tagline) {
-        <div class="rhc-page-footer__tagline">
-          <rhc-heading [level]="2" [appearanceLevel]="appearanceLevel" role="presentation">{{ tagline }}</rhc-heading>
-        </div>
-      }
-      <rhc-column-layout>
-        <ng-content select="[columns]"></ng-content>
-      </rhc-column-layout>
+  <div [class]="`utrecht-page-footer rhc-page-footer ${backgroundClass}`">
+    <div class="utrecht-page-footer__content">
+      <div class="rhc-page-footer-layout">
+        @if (heading) {
+          <h2 aria-hidden="true" hidden>{{ heading }}</h2>
+        }
+        @if (tagline) {
+          <div class="rhc-page-footer__tagline">
+            <rhc-heading [level]="2" [appearanceLevel]="appearanceLevel" role="presentation">{{ tagline }}</rhc-heading>
+          </div>
+        }
+        <rhc-column-layout>
+          <ng-content select="[columns]"></ng-content>
+        </rhc-column-layout>
+      </div>
     </div>
   </div>
 
   @if (subFooter) {
-    <div [class]="`rhc-page-subfooter ${backgroundClass}`">
-      <div class="rhc-page-subfooter__content rhc-page-footer__wrapper">
-        <ng-content select="[subFooter]"></ng-content>
+    <div [class]="`utrecht-page-footer rhc-page-footer rhc-page-footer--subfooter ${backgroundClass}`">
+      <div class="utrecht-page-footer__content">
+        <div class="rhc-page-subfooter-layout">
+          <ng-content select="[subFooter]"></ng-content>
+        </div>
       </div>
     </div>
   }

--- a/packages/components-angular/src/footer/footer.component.html
+++ b/packages/components-angular/src/footer/footer.component.html
@@ -7,18 +7,20 @@
 }
 
 <footer [class]="`utrecht-page-footer rhc-page-footer ${backgroundClass}`">
-  <div class="rhc-page-footer__content rhc-page-footer__wrapper">
-    @if (heading) {
-      <h2 aria-hidden="true" hidden>{{ heading }}</h2>
-    }
-    @if (tagline) {
-      <div class="rhc-page-footer__tagline">
-        <rhc-heading [level]="2" [appearanceLevel]="appearanceLevel" role="presentation">{{ tagline }}</rhc-heading>
-      </div>
-    }
-    <rhc-column-layout>
-      <ng-content select="[columns]"></ng-content>
-    </rhc-column-layout>
+  <div class="utrecht-page-footer__content">
+    <div class="rhc-page-footer-layout">
+      @if (heading) {
+        <h2 aria-hidden="true" hidden>{{ heading }}</h2>
+      }
+      @if (tagline) {
+        <div class="rhc-page-footer__tagline">
+          <rhc-heading [level]="2" [appearanceLevel]="appearanceLevel" role="presentation">{{ tagline }}</rhc-heading>
+        </div>
+      }
+      <rhc-column-layout>
+        <ng-content select="[columns]"></ng-content>
+      </rhc-column-layout>
+    </div>
   </div>
 
   @if (subFooter) {

--- a/packages/components-angular/src/footer/footer.component.spec.ts
+++ b/packages/components-angular/src/footer/footer.component.spec.ts
@@ -76,12 +76,12 @@ describe('FooterComponent in host context', () => {
   });
 
   it('should display subFooter based on input', () => {
-    const subFooterLink = fixture.nativeElement.querySelector('.rhc-page-subfooter');
+    const subFooterLink = fixture.nativeElement.querySelector('.rhc-page-subfooter-layout');
     expect(subFooterLink).toBeTruthy();
 
     component.subFooter = false;
     fixture.detectChanges();
-    const subFooterLinkAfterChange = fixture.nativeElement.querySelector('.rhc-page-subfooter');
+    const subFooterLinkAfterChange = fixture.nativeElement.querySelector('.rhc-page-subfooter-layout');
     expect(subFooterLinkAfterChange).toBeFalsy();
   });
 });

--- a/packages/components-css/library-css/src/footer/index.scss
+++ b/packages/components-css/library-css/src/footer/index.scss
@@ -51,7 +51,7 @@
   border-block-start-width: var(--rhc-page-footer-border-block-start-width);
 }
 
-.rhc-page-footer__content {
+.rhc-page-footer-layout {
   column-gap: var(--rhc-page-footer-column-gap);
   display: flex;
   flex: 1;
@@ -63,16 +63,6 @@
   }
 }
 
-.rhc-page-footer__wrapper {
-  box-sizing: border-box;
-  inline-size: 100%;
-  max-inline-size: var(--rhc-page-footer-content-max-inline-size);
-  padding-block-end: var(--utrecht-page-footer-padding-block-end);
-  padding-block-start: var(--utrecht-page-footer-padding-block-start);
-  padding-inline-end: var(--utrecht-page-footer-padding-inline-end);
-  padding-inline-start: var(--utrecht-page-footer-padding-inline-start);
-}
-
 .rhc-page-footer__section,
 .rhc-page-footer__tagline {
   break-inside: avoid;
@@ -80,7 +70,7 @@
   padding-block-end: var(--rhc-page-footer-padding-block-end);
 }
 
-.rhc-page-footer__content > * {
+.rhc-page-footer-layout > * {
   flex: 1;
 }
 
@@ -109,15 +99,6 @@
   text-decoration: none;
   &:hover {
     text-decoration: var(--rhc-sidenav-link-active-text-decoration);
-  }
-}
-
-@media (width <= 780px) {
-  .rhc-page-footer__wrapper {
-    --utrecht-page-footer-padding-inline-end: var(--rhc-page-footer-padding-inline-end);
-    --utrecht-page-footer-padding-inline-start: var(--rhc-page-footer-padding-inline-start);
-    --utrecht-page-footer-padding-block-end: var(--rhc-page-footer-padding-block-end);
-    --utrecht-page-footer-padding-block-start: var(--rhc-page-footer-padding-block-start);
   }
 }
 

--- a/packages/components-css/library-css/src/footer/index.scss
+++ b/packages/components-css/library-css/src/footer/index.scss
@@ -4,39 +4,31 @@
  */
 
 .rhc-page-footer {
-  --utrecht-space-around: 1;
-  --utrecht-link-hover-text-decoration: underline;
   --_utrecht-link-state-text-decoration-color: currentColor;
-  --utrecht-column-layout-gap: var(--rhc-page-footer-column-gap);
-  --utrecht-column-layout-column-width: var(--rhc-page-footer-column-width);
   --nl-heading-level-1-color: currentColor;
   --nl-heading-level-2-color: currentColor;
   --nl-heading-level-3-color: currentColor;
   --nl-heading-level-4-color: currentColor;
   --nl-heading-level-5-color: currentColor;
   --nl-heading-level-6-color: currentColor;
+  --nl-link-active-color: currentColor;
+  --nl-link-color: currentColor;
+  --nl-link-hover-color: currentColor;
+  --nl-link-text-decoration-color: currentColor;
   --nl-paragraph-color: currentColor;
-
-  align-items: center;
-  display: flex;
-  flex-direction: var(--rhc-page-footer-flex-direction);
-  padding-block: 0;
-  padding-inline: 0;
-
-  :is(.rhc-heading, .rhc-paragraph):is(h1, h2, h3, h4, h5, h6, p) {
-    margin-block-end: var(--utrecht-rich-text-friend-margin-block-end);
-  }
-}
-
-.rhc-page-footer > * {
-  inline-size: 100%;
+  --utrecht-column-layout-column-width: var(--rhc-page-footer-column-width);
+  --utrecht-column-layout-gap: var(--rhc-page-footer-column-gap);
+  --utrecht-link-hover-text-decoration: underline;
+  --utrecht-space-around: 1;
 }
 
 .rhc-page-footer--primary-filled {
   --utrecht-page-footer-background-color: var(--rhc-color-primary-500);
+  --utrecht-page-footer-color: var(--rhc-color-wit);
+  --utrecht-page-footer-content-color: inherit;
 }
 
-.rhc-page-footer--primary-filled.rhc-page-subfooter {
+.rhc-page-footer--primary-filled.rhc-page-footer--subfooter {
   border-block-start-color: var(--rhc-page-footer-border-block-start-color);
   border-block-start-style: var(--rhc-page-footer-border-block-start-style);
   border-block-start-width: var(--rhc-page-footer-border-block-start-width);
@@ -51,16 +43,31 @@
   border-block-start-width: var(--rhc-page-footer-border-block-start-width);
 }
 
+/**
+ * Contains:
+ * - the pre-footer (optional)
+ * - the regular page footer
+ * - the subfooter (optional)
+ */
+.rhc-page-footer-container {
+  display: flex;
+  flex-direction: column;
+  inline-size: 100%;
+}
+
 .rhc-page-footer-layout {
   column-gap: var(--rhc-page-footer-column-gap);
   display: flex;
   flex: 1;
   flex-direction: row;
-  @media (width <= 1024px) {
-    & {
-      flex-direction: var(--rhc-page-footer-flex-direction);
-    }
+
+  :is(.rhc-heading, .rhc-paragraph):is(h1, h2, h3, h4, h5, h6, p) {
+    margin-block-end: var(--utrecht-rich-text-friend-margin-block-end);
   }
+}
+
+.rhc-page-footer-layout > * {
+  flex: 1;
 }
 
 .rhc-page-footer__section,
@@ -70,17 +77,7 @@
   padding-block-end: var(--rhc-page-footer-padding-block-end);
 }
 
-.rhc-page-footer-layout > * {
-  flex: 1;
-}
-
-.rhc-page-subfooter {
-  align-items: center;
-  display: flex;
-  flex-direction: var(--rhc-page-footer-flex-direction);
-}
-
-.rhc-page-subfooter__content {
+.rhc-page-subfooter-layout {
   align-items: center;
   display: flex;
   gap: var(--rhc-page-footer-content-column-gap);
@@ -91,17 +88,6 @@
   }
 }
 
-.rhc-page-subfooter__backtotop {
-  align-items: center;
-  color: inherit;
-  cursor: pointer;
-  display: flex;
-  text-decoration: none;
-  &:hover {
-    text-decoration: var(--rhc-sidenav-link-active-text-decoration);
-  }
-}
-
 .rhc-page-prefooter {
   display: flex;
   justify-content: center;
@@ -109,20 +95,30 @@
 }
 
 .rhc-page-prefooter::before {
-  background-color: var(--rhc-color-primary-500);
-  block-size: 1.5rem;
+  background-color: var(--rhc-color-primary-500, currentColor);
+  block-size: var(--rhc-space-2xl);
   content: "";
-  inline-size: 2rem;
+  inline-size: var(--rhc-space-5xl);
+
+  @media (forced-colors: active) {
+    background-color: CanvasText;
+  }
 }
 
 .rhc-page-prefooter__content {
   font-family: var(--rhc-text-font-family-serif);
   inset: 0% 50% auto auto;
-  line-height: 100%;
+  line-height: 1;
   margin-inline-end: calc(-1 * var(--rhc-space-3xl));
   position: absolute;
   transform: translateX(100%);
+
   @media (width <= 720px) {
+    /*
+     * Hiding the text of this feature is a violation of WCAG SC 1.4.10 Reflow
+     * TODO: Reconsider if the Page Footer Prefooter can be made accessible, or should be removed.
+     * https://nldesignsystem.nl/wcag/1.4.10/
+     */
     & {
       display: none;
     }

--- a/packages/components-react/library-react/src/Footer.test.tsx
+++ b/packages/components-react/library-react/src/Footer.test.tsx
@@ -58,9 +58,21 @@ describe('Footer', () => {
   });
 
   it('applies background class when background prop is provided', () => {
-    render(<Footer background="primary-filled" />);
-    const footerElement = screen.getByRole('contentinfo');
+    const { container } = render(<Footer background="primary-filled" />);
+    const footerElement = container.querySelector('.rhc-page-footer');
     expect(footerElement).toHaveClass('rhc-page-footer--primary-filled');
+  });
+
+  it('renders a landmark with an accessible name', () => {
+    render(<Footer heading="Colofon" />);
+    const footerElement = screen.getByRole('contentinfo', { name: 'Colofon' });
+    expect(footerElement).toBeInTheDocument();
+  });
+
+  it('renders an invisible heading with the landmark name', () => {
+    render(<Footer heading="Colofon" />);
+    const footerElement = screen.getByText('Colofon');
+    expect(footerElement).toHaveAttribute('aria-hidden', 'true');
   });
 
   it('renders children inside the footer', () => {

--- a/packages/components-react/library-react/src/Footer.tsx
+++ b/packages/components-react/library-react/src/Footer.tsx
@@ -73,30 +73,32 @@ export const Footer = ({
         className,
       )}
     >
-      {heading ? (
-        <Heading hidden aria-hidden="true" id={headingId} level={2}>
-          {heading}
-        </Heading>
-      ) : null}
-      <div className="rhc-page-footer__content rhc-page-footer__wrapper">
-        {tagline && (
-          <div className="rhc-page-footer__tagline" key={'heading'}>
-            <Heading appearanceLevel={appearanceLevel} level={2} role="presentation">
-              {tagline}
-            </Heading>
-          </div>
-        )}
-        <ColumnLayout>
-          {columns?.map(({ heading: columnHeading, children }: ColumnProps, index: number) => (
-            <div className="rhc-page-footer__section" key={index}>
-              <Heading appearanceLevel={appearanceLevel} level={heading ? 3 : 2}>
-                {columnHeading}
+      <div className="utrecht-page-footer__content">
+        {heading ? (
+          <Heading hidden aria-hidden="true" id={headingId} level={2}>
+            {heading}
+          </Heading>
+        ) : null}
+        <div className="rhc-page-footer-layout">
+          {tagline && (
+            <div className="rhc-page-footer__tagline" key={'heading'}>
+              <Heading appearanceLevel={appearanceLevel} level={2} role="presentation">
+                {tagline}
               </Heading>
-              {children}
             </div>
-          ))}
-          {children}
-        </ColumnLayout>
+          )}
+          <ColumnLayout>
+            {columns?.map(({ heading: columnHeading, children }: ColumnProps, index: number) => (
+              <div className="rhc-page-footer__section" key={index}>
+                <Heading appearanceLevel={appearanceLevel} level={heading ? 3 : 2}>
+                  {columnHeading}
+                </Heading>
+                {children}
+              </div>
+            ))}
+            {children}
+          </ColumnLayout>
+        </div>
       </div>
       {(backtotop || subFooter) && (
         <div

--- a/packages/components-react/library-react/src/Footer.tsx
+++ b/packages/components-react/library-react/src/Footer.tsx
@@ -4,13 +4,13 @@
  */
 
 import { Icon } from '@rijkshuisstijl-community/icon-react';
-import { PageFooterProps, PageFooter as UtrechtPageFooter } from '@utrecht/component-library-react';
 import clsx from 'clsx';
-import { MouseEvent, PropsWithChildren, ReactNode, Ref } from 'react';
+import { HTMLAttributes, MouseEvent, PropsWithChildren, ReactNode, Ref } from 'react';
 import { ColumnLayout } from './ColumnLayout';
 import { Heading, HeadingLevel } from './Heading';
+import { Link } from './Link';
 
-interface FooterProps extends PageFooterProps {
+interface FooterProps extends HTMLAttributes<HTMLDivElement> {
   heading?: ReactNode;
   headingId?: string;
   appearanceLevel?: HeadingLevel;
@@ -56,18 +56,18 @@ export const Footer = ({
   tagline,
   ...restProps
 }: PropsWithChildren<FooterProps>) => (
-  <>
+  <footer aria-labelledby={heading ? headingId : undefined} className="rhc-page-footer-container">
     {preFooter && (
       <div className="rhc-page-prefooter">
         {preFooterMessage && <span className="rhc-page-prefooter__content">{preFooterMessage}</span>}
       </div>
     )}
 
-    <UtrechtPageFooter
-      aria-labelledby={heading ? headingId : undefined}
+    <div
       {...restProps}
       ref={ref}
       className={clsx(
+        'utrecht-page-footer',
         'rhc-page-footer',
         background ? `rhc-page-footer--${background}` : 'rhc-page-footer--primary-filled',
         className,
@@ -100,25 +100,29 @@ export const Footer = ({
           </ColumnLayout>
         </div>
       </div>
-      {(backtotop || subFooter) && (
-        <div
-          className={clsx(
-            'rhc-page-subfooter',
-            background ? `rhc-page-footer--${background}` : 'rhc-page-footer--primary-filled',
-          )}
-        >
-          <div className="rhc-page-subfooter__content rhc-page-footer__wrapper">
+    </div>
+    {(backtotop || subFooter) && (
+      <div
+        className={clsx(
+          'utrecht-page-footer',
+          'rhc-page-footer',
+          'rhc-page-footer--subfooter',
+          background ? `rhc-page-footer--${background}` : 'rhc-page-footer--primary-filled',
+        )}
+      >
+        <div className="utrecht-page-footer__content">
+          <div className="rhc-page-subfooter-layout">
             {subFooter}
             {backtotop && (
-              <a className="rhc-page-subfooter__backtotop" href="#main" onClick={scrollBackToTop}>
+              <Link href="#main" onClick={scrollBackToTop}>
                 Terug naar boven <Icon icon="pijl-omhoog" />
-              </a>
+              </Link>
             )}
           </div>
         </div>
-      )}
-    </UtrechtPageFooter>
-  </>
+      </div>
+    )}
+  </footer>
 );
 
 Footer.displayName = 'Footer';

--- a/packages/storybook-angular/src/components/footer.stories.ts
+++ b/packages/storybook-angular/src/components/footer.stories.ts
@@ -1,3 +1,4 @@
+import { LinkComponent } from '@rijkshuisstijl-community/components-angular';
 import { type Meta, moduleMetadata, type StoryObj } from '@storybook/angular';
 import { provideTablerIcons, TablerIconComponent } from 'angular-tabler-icons';
 import { IconArrowNarrowUp, IconChevronRight } from 'angular-tabler-icons/icons';
@@ -22,6 +23,7 @@ const meta: Meta<FooterComponent> = {
         LinkListItemComponent,
         LinkListLinkComponent,
         LinkListComponent,
+        LinkComponent,
         HeadingComponent,
         TablerIconComponent,
         IconComponent,
@@ -211,10 +213,10 @@ const meta: Meta<FooterComponent> = {
               </li>
           </rhc-link-list>
         </div>
-        <rhc-back-to-top subFooter>
+        <rhc-link href="#" subFooter>
             Terug naar boven
             <rhc-icon icon><i-tabler name="arrow-narrow-up"/></rhc-icon>
-        </rhc-back-to-top>
+        </rhc-link>
       </footer>
     `,
     props: {

--- a/packages/storybook-angular/src/templates/shared/page-layout/page-layout.component.html
+++ b/packages/storybook-angular/src/templates/shared/page-layout/page-layout.component.html
@@ -129,10 +129,8 @@
       </li>
     </rhc-link-list>
   </div>
-  <rhc-back-to-top subFooter>
+  <rhc-link href="#" subFooter>
     Terug naar boven
-    <rhc-icon>
-      <i-tabler name="arrow-narrow-up" />
-    </rhc-icon>
-  </rhc-back-to-top>
+    <rhc-icon icon><i-tabler name="arrow-narrow-up" /></rhc-icon>
+  </rhc-link>
 </footer>

--- a/packages/storybook-angular/src/templates/shared/page-layout/page-layout.component.ts
+++ b/packages/storybook-angular/src/templates/shared/page-layout/page-layout.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { LinkComponent } from '@rijkshuisstijl-community/components-angular';
 import {
   BackToTopComponent,
   FooterComponent,
@@ -37,6 +38,7 @@ import {
     FooterComponent,
     TablerIconComponent,
     HeadingComponent,
+    LinkComponent,
     LinkListComponent,
     LinkListLinkComponent,
     LinkListItemComponent,

--- a/packages/storybook/src/components-react/footer.stories.tsx
+++ b/packages/storybook/src/components-react/footer.stories.tsx
@@ -134,7 +134,7 @@ export const DefaultFooter: Story = {
 
 export const PrimaryOutlinedFooter: Story = {
   args: {
-    tagline: 'Footer taglne',
+    tagline: 'Footer tagline',
     appearanceLevel: 3,
     background: 'primary-outlined',
     preFooterMessage: '',

--- a/packages/storybook/src/templates/details/index.css
+++ b/packages/storybook/src/templates/details/index.css
@@ -32,47 +32,14 @@
   display: flex;
   inline-size: 100%;
   justify-content: flex-start;
-  max-inline-size: 64rem;
-  padding-block-end: var(--rhc-space-700);
-  padding-block-start: var(--rhc-space-2xl);
-  padding-inline-end: var(--rhc-space-700);
-  padding-inline-start: var(--rhc-space-700);
+  padding-block-end: var(--rhc-size-half-lint);
+  padding-block-start: var(--rhc-size-half-lint);
+  padding-inline-end: var(--rhc-size-half-lint);
+  padding-inline-start: var(--rhc-size-half-lint);
   position: static;
   transform: translateY(0%);
 
   & .rhc-link-list-card {
     max-inline-size: 24rem;
-  }
-  @media (width <= 780px) {
-    padding-block-end: var(--rhc-space-700);
-    padding-block-start: var(--rhc-space-700);
-    padding-inline-end: var(--rhc-space-xl);
-    padding-inline-start: var(--rhc-space-xl);
-  }
-}
-
-/**
- * Custom subnavbar styling, pre-existing in templates.
- * TODO: Discuss with team and design if this is intended, and if so, if it should be moved to the component.
- */
-.rhc-subnavbar-details-template .rhc-sub-nav-bar__content {
-  box-sizing: border-box;
-  max-inline-size: 64rem;
-  padding-inline-end: var(--rhc-space-700);
-  padding-inline-start: var(--rhc-space-700);
-  @media (width <= 780px) {
-    padding-inline-end: var(--rhc-space-xl);
-    padding-inline-start: var(--rhc-space-xl);
-  }
-}
-
-/**
- * Provide spacing between linked list's in a column to match the list item gap.
- */
-.rhc-linklist-collection {
-  @media (width <= 930px) {
-    display: flex;
-    flex-direction: column;
-    gap: var(--rhc-space-md);
   }
 }

--- a/packages/storybook/src/templates/globals.css
+++ b/packages/storybook/src/templates/globals.css
@@ -42,37 +42,21 @@ body {
   display: flex;
   flex: 1;
   flex-direction: column;
-  row-gap: var(--rhc-space-700);
+  row-gap: var(--rhc-size-lint);
 }
 
 .rhc-templates-page-content {
-  --utrecht-page-content-padding-block-end: var(--rhc-space-5xl);
-  --utrecht-page-content-padding-block-start: var(--rhc-space-5xl);
-  --utrecht-page-padding-inline-end: var(--rhc-space-700);
-  --utrecht-page-padding-inline-start: var(--rhc-space-700);
-
   align-items: stretch;
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  gap: var(--rhc-space-5xl);
+  gap: var(--rhc-size-lint);
   inline-size: 100%;
-  margin-block-end: var(--rhc-space-700, 80px); /* replacement is not an exact match: 56px vs 80px */
-  margin-block-start: var(--rhc-space-700, 80px); /* replacement is not an exact match: 56px vs 80px */
-  max-inline-size: 64rem;
+  padding-block-end: var(--rhc-size-quarter-lint);
+  padding-block-start: var(--rhc-size-quarter-lint);
+  padding-inline-end: var(--rhc-size-quarter-lint);
+  padding-inline-start: var(--rhc-size-quarter-lint);
 }
-
-/*
-@media (width <= 780px) {
-  .rhc-templates-page-content {
-    --utrecht-page-content-padding-block-end: var(--rhc-space-3xl);
-    --utrecht-page-content-padding-block-start: var(--rhc-space-3xl);
-    --utrecht-page-padding-inline-end: var(--rhc-space-xl);
-    --utrecht-page-padding-inline-start: var(--rhc-space-xl);
-
-    margin-block-end: var(--rhc-space-none);
-    margin-block-start: var(--rhc-space-none);
-  }
-} */
 
 /**
  * Mimic the non-existing Card Group

--- a/packages/storybook/src/templates/mijn-omgeving/index.css
+++ b/packages/storybook/src/templates/mijn-omgeving/index.css
@@ -8,5 +8,4 @@
 .utrecht-page-body--rhc-mijn-omgeving .rhc-templates-page-content {
   flex-direction: row;
   flex-wrap: wrap;
-  max-inline-size: 1100px;
 }

--- a/packages/storybook/src/templates/shared/header.css
+++ b/packages/storybook/src/templates/shared/header.css
@@ -6,6 +6,11 @@
   --rhc-nav-bar-link-hover-background-color: #dce3ea;
 }
 
+.rhc-page-header-layout {
+  display: grid;
+  row-gap: var(--rhc-size-quarter-lint);
+}
+
 /**
 * Temporary demo solution for acceptably responsive nav bar.
 * TODO: Discuss responsive design with design team.

--- a/packages/storybook/src/templates/shared/header.tsx
+++ b/packages/storybook/src/templates/shared/header.tsx
@@ -40,27 +40,29 @@ export default function SharedHeader() {
       <SkipLink className="rhc-skip-link--visible-on-focus" href="#main" id="top">
         Ga naar hoofdinhoud
       </SkipLink>
-      <Logo organisation="Rijkshuisstijl Community">
-        <Icon className={'dutch-map'} icon={'nederland-map'} />
-      </Logo>
-      <NavBar
-        items={items}
-        endItems={[
-          {
-            id: 'end1',
-            target: '_blank',
-            href: 'https://www.figma.com/design/Q5Imc7Xi9KnBQhcYI3Hytj/NL-Design-System---Bibliotheek---Rijkshuisstijl-Community',
-            label: 'Figma',
-          },
-          {
-            id: 'end2',
-            target: '_blank',
-            href: 'https://github.com/nl-design-system/rijkshuisstijl-community',
-            label: 'GitHub',
-          },
-          { id: 'end3', target: '_blank', href: 'https://rijkshuisstijl-community.vercel.app/', label: 'Storybook' },
-        ]}
-      />
+      <div className="rhc-page-header-layout">
+        <Logo organisation="Rijkshuisstijl Community">
+          <Icon className={'dutch-map'} icon={'nederland-map'} />
+        </Logo>
+        <NavBar
+          items={items}
+          endItems={[
+            {
+              id: 'end1',
+              target: '_blank',
+              href: 'https://www.figma.com/design/Q5Imc7Xi9KnBQhcYI3Hytj/NL-Design-System---Bibliotheek---Rijkshuisstijl-Community',
+              label: 'Figma',
+            },
+            {
+              id: 'end2',
+              target: '_blank',
+              href: 'https://github.com/nl-design-system/rijkshuisstijl-community',
+              label: 'GitHub',
+            },
+            { id: 'end3', target: '_blank', href: 'https://rijkshuisstijl-community.vercel.app/', label: 'Storybook' },
+          ]}
+        />
+      </div>
     </PageHeader>
   );
 }

--- a/packages/storybook/src/templates/shared/main-page-content.tsx
+++ b/packages/storybook/src/templates/shared/main-page-content.tsx
@@ -1,10 +1,9 @@
-import { PageContent } from '@rijkshuisstijl-community/components-react';
 import { PropsWithChildren } from 'react';
 
 export default function SharedMainPageContent({ children }: PropsWithChildren<{}>) {
   return (
     <div className="rhc-templates-main-content">
-      <PageContent className="rhc-templates-page-content">{children}</PageContent>
+      <div className="rhc-templates-page-content">{children}</div>
     </div>
   );
 }

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -6110,19 +6110,37 @@
         },
         "padding-block-start": {
           "$type": "dimension",
-          "$value": "{rhc.space.5xl}"
+          "$value": "{rhc.space.none}"
         },
         "padding-block-end": {
           "$type": "dimension",
-          "$value": "{rhc.space.5xl}"
+          "$value": "{rhc.space.none}"
         },
         "padding-inline-start": {
           "$type": "dimension",
-          "$value": "80px"
+          "$value": "{rhc.space.none}"
         },
         "padding-inline-end": {
           "$type": "dimension",
-          "$value": "80px"
+          "$value": "{rhc.space.none}"
+        },
+        "content": {
+          "max-inline-size": {
+            "$type": "dimension",
+            "$value": "{rhc.size.page.md}"
+          },
+          "padding-block-start": {
+            "$type": "dimension",
+            "$value": "{rhc.size.lint}"
+          },
+          "padding-block-end": {
+            "$type": "dimension",
+            "$value": "{rhc.size.lint}"
+          },
+          "padding-inline": {
+            "$type": "dimension",
+            "$value": "{rhc.size.quarter-lint}"
+          }
         }
       }
     },


### PR DESCRIPTION
Ik wil de page layout componenten op een nieuwe manier structureren. De essentie is:

- nieuwest versies van bestaande Root/Body/Page Header/Page Footer/Page Body gebruiken
- oude utrecht-page-content uitfaseren
- `__content` divjes toevoegen die de boel centreren
- zorgen dat de Page Footer er ook goed (genoeg) uit ziet wanneer niet rhc-footer is gebruikt maar utrecht-page-footer (met het idee: dat het later compatible is met nl-page-footer in situaties waar niet speciaal de rhc-page-footer nodig of mogelijk is met de optie voor pre/sub footer)
- wrapper om de footer zodat de pre-footer en subfooter in de `<footer>` landmark vallen
- de Rijkshuisstijl-specifieke layout van de header en footer in een losse class name: `utrecht-page-header-layout` en `utrecht-page-footer-layout`, die we binnenkort kunnen veranderen naar `display: grid` met area's voor responsive varianten op basis van container queries
- zoveel mogelijk verplaatsen van templates naar componenten, zodat je out of the box de basis pagina kan opzetten

Dus:

- `utrecht-root`
  - `utrecht-body`
    - `utrecht-page-layout`
      - `utrecht-page-header`
        - `utrecht-page-header__content`
          - `rhc-page-header-layout`
      - `utrecht-page-body`
        - `utrecht-page-body__content`
          - `rhc-page-body-layout` `rhc-page-body-layout--side-nav` of `rhc-page-body-layout--homepage`
      - `rhc-page-footer` met `<footer>`
        - `rhc-page-footer__pre-footer`
        - `utrecht-page-footer` zonder `<footer>`
          - `utrecht-page-footer__content`
            - `rhc-page-footer-layout`
        - `rhc-page-footer__sub-footer`
