### PR TITLE
core token + on-primary token nav Norday alignment

### DIFF
--- a/.changeset/divide-green-yellow.md
+++ b/.changeset/divide-green-yellow.md
@@ -1,0 +1,8 @@
+---
+'@rijkshuisstijl-community/design-tokens': minor
+---
+
+Na afstemming met Norday (DPC samenwerking Rijkshuisstijl.nl) zijn de volgende common tokens toegevoegd, in voorbereiding op de herziene richtlijnen van Rijkshuisstijl.nl:
+
+- `rhc.color.core.*` toegevoegd (`.50` t/m `.500`, `.hover`, `.active`) - voorheen verwees de kernkleur lintblauw direct naar de brand-laag, dit introduceert een common token als tussenlaag.
+- `rhc.color.foreground.on-primary` toegevoegd — maakt het eenvoudiger om van primary kleur te wisselen zonder tekstkleur apart aan te passen.

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -724,6 +724,16 @@
           "500": {
             "$type": "color",
             "$value": "oklch(49.37% 0.11351 240.39)"
+          },
+          "600": {
+            "$type": "color",
+            "$value": "oklch(38.54% 0.0857 238.6)",
+            "$description": "Originally rhc.color.donkerblauw.500 darkened (srgb) with modify by 0.3"
+          },
+          "700": {
+            "$type": "color",
+            "$value": "oklch(35.32% 0.0666 242.1)",
+            "$description": "Originally rhc.color.donkerblauw.500 darkened (lch) by 0.4"
           }
         },
         "mintgroen": {
@@ -1038,6 +1048,18 @@
             "$value": "oklch(53.943% 0.21669 5.2)"
           }
         },
+        "wit": {
+          "$type": "color",
+          "$value": "oklch(100% 0 0)"
+        },
+        "zwart": {
+          "$type": "color",
+          "$value": "oklch(0% 0 0)"
+        },
+        "transparent": {
+          "$type": "color",
+          "$value": "transparent"
+        },
         "lintblauw": {
           "50": {
             "$type": "color",
@@ -1063,18 +1085,6 @@
             "$type": "color",
             "$value": "oklch(37.619% 0.09695 253.44)"
           }
-        },
-        "wit": {
-          "$type": "color",
-          "$value": "oklch(100% 0 0)"
-        },
-        "zwart": {
-          "$type": "color",
-          "$value": "oklch(0% 0 0)"
-        },
-        "transparent": {
-          "$type": "color",
-          "$value": "transparent"
         }
       }
     }
@@ -1386,18 +1396,6 @@
   "common/color": {
     "rhc": {
       "color": {
-        "donkerblauw": {
-          "600": {
-            "$type": "color",
-            "$value": "oklch(38.54% 0.0857 238.6)",
-            "$description": "Originally rhc.color.donkerblauw.500 darkened (srgb) with modify by 0.3"
-          },
-          "700": {
-            "$type": "color",
-            "$value": "oklch(35.32% 0.0666 242.1)",
-            "$description": "Originally rhc.color.donkerblauw.500 darkened (lch) by 0.4"
-          }
-        },
         "foreground": {
           "default": {
             "$type": "color",
@@ -1422,6 +1420,10 @@
           "on-dark-color": {
             "$type": "color",
             "$value": "{rhc.color.wit}"
+          },
+          "on-primary": {
+            "$type": "color",
+            "$value": "{rhc.color.foreground.on-dark-color}"
           },
           "on-light-color": {
             "$type": "color",
@@ -1487,6 +1489,42 @@
           }
         },
         "primary": {
+          "50": {
+            "$type": "color",
+            "$value": "{rhc.color.lintblauw.50}"
+          },
+          "100": {
+            "$type": "color",
+            "$value": "{rhc.color.lintblauw.100}"
+          },
+          "200": {
+            "$type": "color",
+            "$value": "{rhc.color.lintblauw.200}"
+          },
+          "300": {
+            "$type": "color",
+            "$value": "{rhc.color.lintblauw.300}"
+          },
+          "400": {
+            "$type": "color",
+            "$value": "{rhc.color.lintblauw.400}"
+          },
+          "500": {
+            "$type": "color",
+            "$value": "{rhc.color.lintblauw.500}"
+          },
+          "hover": {
+            "$type": "color",
+            "$value": "oklch(30.37% 0.0676 256.1)",
+            "$description": "Originally rhc.color.primary.500 darkened (lch) by 0.3"
+          },
+          "active": {
+            "$type": "color",
+            "$value": "oklch(28.03% 0.0577 258)",
+            "$description": "Originally rhc.color.primary.500 darkened (lch) by 0.4"
+          }
+        },
+        "core": {
           "50": {
             "$type": "color",
             "$value": "{rhc.color.lintblauw.50}"
@@ -1747,7 +1785,7 @@
       "heading": {
         "color": {
           "$type": "color",
-          "$value": "{rhc.color.lintblauw.500}"
+          "$value": "{rhc.color.core.500}"
         },
         "font-family": {
           "$type": "fontFamilies",
@@ -2309,7 +2347,7 @@
         },
         "color": {
           "$type": "color",
-          "$value": "{rhc.color.lintblauw.500}"
+          "$value": "{rhc.color.core.500}"
         },
         "font-size": {
           "$type": "fontSizes",
@@ -2342,7 +2380,7 @@
         "attribution": {
           "color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "font-size": {
             "$type": "fontSizes",
@@ -2352,7 +2390,7 @@
         "content": {
           "color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "font-size": {
             "$type": "fontSizes",
@@ -2690,7 +2728,7 @@
           },
           "color": {
             "$type": "color",
-            "$value": "{rhc.color.foreground.on-dark-color}"
+            "$value": "{rhc.color.foreground.on-primary}"
           },
           "font-size": {
             "$type": "fontSizes",
@@ -2729,7 +2767,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{rhc.color.foreground.on-dark-color}"
+              "$value": "{rhc.color.foreground.on-primary}"
             }
           },
           "focus": {
@@ -2743,7 +2781,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{rhc.color.foreground.on-dark-color}"
+              "$value": "{rhc.color.foreground.on-primary}"
             }
           },
           "pressed": {
@@ -2753,7 +2791,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{rhc.color.foreground.on-dark-color}"
+              "$value": "{rhc.color.foreground.on-primary}"
             },
             "background-color": {
               "$type": "color",
@@ -2767,7 +2805,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{rhc.color.foreground.on-dark-color}"
+              "$value": "{rhc.color.foreground.on-primary}"
             },
             "background-color": {
               "$type": "color",
@@ -3040,7 +3078,7 @@
         "icon": {
           "color": {
             "$type": "color",
-            "$value": "{rhc.color.primary.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "size": {
             "$type": "dimension",
@@ -3050,7 +3088,7 @@
         "link": {
           "color": {
             "$type": "color",
-            "$value": "{rhc.color.donkerblauw.500}"
+            "$value": "{rhc.color.foreground.link}"
           },
           "text-decoration": {
             "$type": "textDecoration",
@@ -3124,7 +3162,7 @@
         "focus": {
           "background-color": {
             "$type": "color",
-            "$value": "{rhc.color.primary.50}"
+            "$value": "{rhc.color.core.50}"
           },
           "text-decoration": {
             "$type": "textDecoration",
@@ -3152,7 +3190,7 @@
         "heading": {
           "color": {
             "$type": "color",
-            "$value": "{rhc.color.primary.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "padding-block-start": {
             "$type": "dimension",
@@ -3176,7 +3214,7 @@
         "horizontal": {
           "background-color": {
             "$type": "color",
-            "$value": "{rhc.color.primary.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "border-color": {
             "$type": "color",
@@ -3250,7 +3288,7 @@
         "icon": {
           "color": {
             "$type": "color",
-            "$value": "{rhc.color.primary.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "size": {
             "$type": "dimension",
@@ -3260,7 +3298,7 @@
         "link": {
           "color": {
             "$type": "color",
-            "$value": "{rhc.color.donkerblauw.500}"
+            "$value": "{rhc.color.foreground.link}"
           },
           "text-decoration": {
             "$type": "textDecoration",
@@ -3334,7 +3372,7 @@
         "focus": {
           "background-color": {
             "$type": "color",
-            "$value": "{rhc.color.primary.50}"
+            "$value": "{rhc.color.core.50}"
           },
           "text-decoration": {
             "$type": "textDecoration",
@@ -3362,7 +3400,7 @@
         "heading": {
           "color": {
             "$type": "color",
-            "$value": "{rhc.color.primary.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "padding-block-start": {
             "$type": "dimension",
@@ -3380,7 +3418,7 @@
         "horizontal": {
           "background-color": {
             "$type": "color",
-            "$value": "{rhc.color.primary.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "border-color": {
             "$type": "color",
@@ -3457,7 +3495,7 @@
         },
         "border-color": {
           "$type": "color",
-          "$value": "{rhc.color.lintblauw.500}"
+          "$value": "{rhc.color.core.500}"
         },
         "border-radius": {
           "$type": "dimension",
@@ -3502,7 +3540,7 @@
           },
           "border-color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.400}"
+            "$value": "{rhc.color.core.400}"
           },
           "border-width": {
             "$type": "dimension",
@@ -3526,7 +3564,7 @@
           },
           "border-color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.300}"
+            "$value": "{rhc.color.core.300}"
           },
           "border-width": {
             "$type": "dimension",
@@ -3540,7 +3578,7 @@
           },
           "border-color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "border-width": {
             "$type": "dimension",
@@ -3550,7 +3588,7 @@
         "indeterminate": {
           "background-color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "border-color": {
             "$type": "color",
@@ -3599,7 +3637,7 @@
           "hover": {
             "background-color": {
               "$type": "color",
-              "$value": "{rhc.color.primary.300}"
+              "$value": "{rhc.color.core.300}"
             },
             "border-color": {
               "$type": "color",
@@ -3621,11 +3659,11 @@
             },
             "border-color": {
               "$type": "color",
-              "$value": "{rhc.color.primary.500}"
+              "$value": "{rhc.color.core.500}"
             },
             "color": {
               "$type": "color",
-              "$value": "{rhc.color.primary.500}"
+              "$value": "{rhc.color.core.500}"
             },
             "border-width": {
               "$type": "dimension",
@@ -3636,7 +3674,7 @@
         "checked": {
           "background-color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "border-color": {
             "$type": "color",
@@ -3707,11 +3745,11 @@
             },
             "border-color": {
               "$type": "color",
-              "$value": "{rhc.color.primary.500}"
+              "$value": "{rhc.color.core.500}"
             },
             "color": {
               "$type": "color",
-              "$value": "{rhc.color.primary.500}"
+              "$value": "{rhc.color.core.500}"
             },
             "border-width": {
               "$type": "dimension",
@@ -3727,7 +3765,7 @@
           "active": {
             "background-color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.400}"
+              "$value": "{rhc.color.core.400}"
             },
             "border-color": {
               "$type": "color",
@@ -3759,7 +3797,7 @@
           "hover": {
             "background-color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.300}"
+              "$value": "{rhc.color.core.300}"
             },
             "border-color": {
               "$type": "color",
@@ -3781,7 +3819,7 @@
             },
             "border-color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.500}"
+              "$value": "{rhc.color.core.500}"
             },
             "border-width": {
               "$type": "dimension",
@@ -3789,7 +3827,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.500}"
+              "$value": "{rhc.color.core.500}"
             }
           }
         },
@@ -3797,7 +3835,7 @@
           "active": {
             "background-color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.400}"
+              "$value": "{rhc.color.core.400}"
             },
             "border-color": {
               "$type": "color",
@@ -3829,7 +3867,7 @@
           "hover": {
             "background-color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.300}"
+              "$value": "{rhc.color.core.300}"
             },
             "border-color": {
               "$type": "color",
@@ -3851,7 +3889,7 @@
             },
             "border-color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.500}"
+              "$value": "{rhc.color.core.500}"
             },
             "border-width": {
               "$type": "dimension",
@@ -3859,7 +3897,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.500}"
+              "$value": "{rhc.color.core.500}"
             }
           }
         }
@@ -3921,7 +3959,7 @@
         },
         "color": {
           "$type": "color",
-          "$value": "{rhc.color.primary.500}"
+          "$value": "{rhc.color.core.500}"
         },
         "padding-block": {
           "$type": "dimension",
@@ -3944,7 +3982,7 @@
         "hover": {
           "background-color": {
             "$type": "color",
-            "$value": "{rhc.color.primary.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "color": {
             "$type": "color",
@@ -4352,7 +4390,7 @@
         },
         "border-color": {
           "$type": "color",
-          "$value": "{rhc.color.primary.500}"
+          "$value": "{rhc.color.core.500}"
         },
         "border-width": {
           "$type": "dimension",
@@ -4697,7 +4735,7 @@
         "level-1": {
           "color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "font-family": {
             "$type": "fontFamilies",
@@ -4729,7 +4767,7 @@
         "level-2": {
           "color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "font-family": {
             "$type": "fontFamilies",
@@ -4761,7 +4799,7 @@
         "level-3": {
           "color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "font-family": {
             "$type": "fontFamilies",
@@ -4793,7 +4831,7 @@
         "level-4": {
           "color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "font-family": {
             "$type": "fontFamilies",
@@ -4825,7 +4863,7 @@
         "level-5": {
           "color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "font-family": {
             "$type": "fontFamilies",
@@ -4857,7 +4895,7 @@
         "level-6": {
           "color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "font-family": {
             "$type": "fontFamilies",
@@ -4931,7 +4969,7 @@
         "message": {
           "background-color": {
             "$type": "color",
-            "$value": "{rhc.color.primary.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "color": {
             "$type": "color",
@@ -5130,7 +5168,7 @@
         "active": {
           "color": {
             "$type": "color",
-            "$value": "oklch(39.49% 0.086 248.3)",
+            "$value": "{rhc.color.foreground.link-active}",
             "$description": "Originally rhc.color.hemelblauw.500 darkened (lch) with modify by 0.4"
           }
         },
@@ -5316,7 +5354,7 @@
           "selected": {
             "background-color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.500}"
+              "$value": "{rhc.color.core.500}"
             },
             "color": {
               "$type": "color",
@@ -5455,7 +5493,7 @@
           },
           "color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.500}"
+            "$value": "{rhc.color.core.500}"
           }
         },
         "title": {
@@ -5500,7 +5538,7 @@
         },
         "color": {
           "$type": "color",
-          "$value": "{rhc.color.lintblauw.500}"
+          "$value": "{rhc.color.core.500}"
         }
       }
     }
@@ -5640,7 +5678,7 @@
           "active": {
             "background-color": {
               "$type": "color",
-              "$value": "{rhc.color.primary.500}"
+              "$value": "{rhc.color.core.500}"
             },
             "color": {
               "$type": "color",
@@ -5653,7 +5691,7 @@
           },
           "color": {
             "$type": "color",
-            "$value": "{rhc.color.primary.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "focus": {
             "background-color": {
@@ -5662,7 +5700,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{rhc.color.primary.500}"
+              "$value": "{rhc.color.core.500}"
             }
           },
           "hover": {
@@ -5672,7 +5710,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{rhc.color.primary.500}"
+              "$value": "{rhc.color.core.500}"
             }
           },
           "padding-block-end": {
@@ -5712,11 +5750,11 @@
         },
         "color": {
           "$type": "color",
-          "$value": "{rhc.color.primary.500}"
+          "$value": "{rhc.color.core.500}"
         },
         "border-color": {
           "$type": "color",
-          "$value": "{rhc.color.primary.400}"
+          "$value": "{rhc.color.core.400}"
         }
       }
     }
@@ -5768,7 +5806,7 @@
           "focus": {
             "background-color": {
               "$type": "color",
-              "$value": "{rhc.color.primary.50}"
+              "$value": "{rhc.color.core.50}"
             }
           },
           "content": {
@@ -5860,7 +5898,7 @@
       "number-badge": {
         "background-color": {
           "$type": "color",
-          "$value": "{rhc.color.primary.500}"
+          "$value": "{rhc.color.core.500}"
         },
         "border-color": {
           "$type": "color",
@@ -6062,7 +6100,7 @@
       "page-footer": {
         "background-color": {
           "$type": "color",
-          "$value": "{rhc.color.primary.500}"
+          "$value": "{rhc.color.core.500}"
         },
         "color": {
           "$type": "color",
@@ -6128,7 +6166,7 @@
         },
         "border-block-start-color": {
           "$type": "color",
-          "$value": "{rhc.color.primary.300}"
+          "$value": "{rhc.color.core.300}"
         },
         "border-block-start-style": {
           "$type": "other",
@@ -6141,11 +6179,11 @@
           },
           "color": {
             "$type": "color",
-            "$value": "{rhc.color.primary.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "border-color": {
             "$type": "color",
-            "$value": "{rhc.color.primary.500}"
+            "$value": "{rhc.color.core.500}"
           }
         },
         "padding-block-start": {
@@ -6324,7 +6362,7 @@
         },
         "border-color": {
           "$type": "color",
-          "$value": "{rhc.color.lintblauw.500}"
+          "$value": "{rhc.color.core.500}"
         },
         "color": {
           "$type": "color",
@@ -6373,7 +6411,7 @@
           },
           "border-color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.400}"
+            "$value": "{rhc.color.core.400}"
           },
           "color": {
             "$type": "color",
@@ -6405,7 +6443,7 @@
           },
           "border-color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.300}"
+            "$value": "{rhc.color.core.300}"
           },
           "color": {
             "$type": "color",
@@ -6423,7 +6461,7 @@
           },
           "border-color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "color": {
             "$type": "color",
@@ -6437,7 +6475,7 @@
         "checked": {
           "background-color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "border-color": {
             "$type": "color",
@@ -6454,7 +6492,7 @@
           "active": {
             "background-color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.400}"
+              "$value": "{rhc.color.core.400}"
             },
             "border-color": {
               "$type": "color",
@@ -6472,7 +6510,7 @@
           "hover": {
             "background-color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.300}"
+              "$value": "{rhc.color.core.300}"
             },
             "border-color": {
               "$type": "color",
@@ -6494,7 +6532,7 @@
             },
             "border-color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.500}"
+              "$value": "{rhc.color.core.500}"
             },
             "border-width": {
               "$type": "dimension",
@@ -6502,7 +6540,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.500}"
+              "$value": "{rhc.color.core.500}"
             }
           }
         }
@@ -6614,7 +6652,7 @@
         },
         "border-color": {
           "$type": "color",
-          "$value": "{rhc.color.primary.500}"
+          "$value": "{rhc.color.core.500}"
         },
         "border-radius": {
           "$type": "dimension",
@@ -6719,7 +6757,7 @@
           },
           "border-color": {
             "$type": "color",
-            "$value": "{rhc.color.primary.300}"
+            "$value": "{rhc.color.core.300}"
           },
           "color": {
             "$type": "color",
@@ -6733,7 +6771,7 @@
           },
           "border-color": {
             "$type": "color",
-            "$value": "{rhc.color.primary.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "border-width": {
             "$type": "dimension",
@@ -6844,11 +6882,11 @@
             },
             "border-color": {
               "$type": "color",
-              "$value": "{rhc.color.primary.500}"
+              "$value": "{rhc.color.core.500}"
             },
             "background-color": {
               "$type": "color",
-              "$value": "none"
+              "$value": "{rhc.color.transparent}"
             },
             "color": {
               "$type": "color",
@@ -7315,7 +7353,7 @@
           },
           "border-color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.300}"
+            "$value": "{rhc.color.core.300}"
           },
           "color": {
             "$type": "color",
@@ -7336,7 +7374,7 @@
         },
         "border-color": {
           "$type": "color",
-          "$value": "{rhc.color.lintblauw.500}"
+          "$value": "{rhc.color.core.500}"
         },
         "border-radius": {
           "$type": "dimension",
@@ -7453,7 +7491,7 @@
           },
           "border-color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "color": {
             "$type": "color",
@@ -7473,7 +7511,7 @@
           },
           "border-color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.300}"
+            "$value": "{rhc.color.core.300}"
           },
           "border-width": {
             "$type": "dimension",
@@ -7513,7 +7551,7 @@
           },
           "border-color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.300}"
+            "$value": "{rhc.color.core.300}"
           },
           "color": {
             "$type": "color",
@@ -7534,7 +7572,7 @@
         },
         "border-color": {
           "$type": "color",
-          "$value": "{rhc.color.lintblauw.500}"
+          "$value": "{rhc.color.core.500}"
         },
         "border-radius": {
           "$type": "dimension",
@@ -7651,7 +7689,7 @@
           },
           "border-color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "color": {
             "$type": "color",
@@ -7909,6 +7947,12 @@
             "$type": "color",
             "$value": "oklch(38.71% 0.1016 137.1)"
           }
+        },
+        "foreground": {
+          "on-primary": {
+            "$type": "color",
+            "$value": "{rhc.color.foreground.on-dark-color}"
+          }
         }
       }
     }
@@ -7948,6 +7992,12 @@
           "active": {
             "$type": "color",
             "$value": "oklch(39.49% 0.086 248.3)"
+          }
+        },
+        "foreground": {
+          "on-primary": {
+            "$type": "color",
+            "$value": "{rhc.color.foreground.on-dark-color}"
           }
         }
       }
@@ -7989,6 +8039,12 @@
             "$type": "color",
             "$value": "oklch(60.03% 0.0691 172.6)"
           }
+        },
+        "foreground": {
+          "on-primary": {
+            "$type": "color",
+            "$value": "{rhc.color.foreground.on-light-color}"
+          }
         }
       }
     }
@@ -8028,6 +8084,12 @@
           "active": {
             "$type": "color",
             "$value": "oklch(45.34% 0.1055 53.92)"
+          }
+        },
+        "foreground": {
+          "on-primary": {
+            "$type": "color",
+            "$value": "{rhc.color.foreground.on-dark-color}"
           }
         }
       }
@@ -8069,6 +8131,12 @@
             "$type": "color",
             "$value": "oklch(23.97% 0.0791 311.1)"
           }
+        },
+        "foreground": {
+          "on-primary": {
+            "$type": "color",
+            "$value": "{rhc.color.foreground.on-dark-color}"
+          }
         }
       }
     }
@@ -8108,6 +8176,12 @@
           "active": {
             "$type": "color",
             "$value": "oklch(38% 0.1293 5.781)"
+          }
+        },
+        "foreground": {
+          "on-primary": {
+            "$type": "color",
+            "$value": "{rhc.color.foreground.on-dark-color}"
           }
         }
       }
@@ -8149,6 +8223,12 @@
             "$type": "color",
             "$value": "oklch(52.01% 0.0797 343.1)"
           }
+        },
+        "foreground": {
+          "on-primary": {
+            "$type": "color",
+            "$value": "{rhc.color.foreground.on-light-color}"
+          }
         }
       }
     }
@@ -8189,6 +8269,12 @@
             "$type": "color",
             "$value": "oklch(34.12% 0.1167 356.1)"
           }
+        },
+        "foreground": {
+          "on-primary": {
+            "$type": "color",
+            "$value": "{rhc.color.foreground.on-dark-color}"
+          }
         }
       }
     }
@@ -8199,17 +8285,8 @@
         "primary-action": {
           "hover": {
             "background-color": {
-              "$extensions": {
-                "studio.tokens": {
-                  "modify": {
-                    "type": "darken",
-                    "value": "0.3",
-                    "space": "lch"
-                  }
-                }
-              },
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.500}"
+              "$value": "{rhc.color.core.hover}"
             },
             "border-color": {
               "$type": "color",
@@ -8222,7 +8299,7 @@
           },
           "background-color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "border-color": {
             "$type": "color",
@@ -8235,7 +8312,7 @@
           "disabled": {
             "background-color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.100}"
+              "$value": "{rhc.color.core.100}"
             },
             "border-color": {
               "$type": "color",
@@ -8243,13 +8320,13 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.400}"
+              "$value": "{rhc.color.core.400}"
             }
           },
           "focus": {
             "background-color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.500}"
+              "$value": "{rhc.color.core.500}"
             },
             "border-color": {
               "$type": "color",
@@ -8262,17 +8339,8 @@
           },
           "active": {
             "background-color": {
-              "$extensions": {
-                "studio.tokens": {
-                  "modify": {
-                    "type": "darken",
-                    "value": "0.4",
-                    "space": "srgb"
-                  }
-                }
-              },
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.500}"
+              "$value": "{rhc.color.core.active}"
             },
             "border-color": {
               "$type": "color",
@@ -8285,17 +8353,8 @@
           },
           "pressed": {
             "background-color": {
-              "$extensions": {
-                "studio.tokens": {
-                  "modify": {
-                    "type": "darken",
-                    "value": "0.4",
-                    "space": "lch"
-                  }
-                }
-              },
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.500}"
+              "$value": "{rhc.color.core.active}"
             },
             "border-color": {
               "$type": "color",
@@ -8311,33 +8370,15 @@
           "hover": {
             "background-color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.50}"
+              "$value": "{rhc.color.core.50}"
             },
             "border-color": {
-              "$extensions": {
-                "studio.tokens": {
-                  "modify": {
-                    "type": "darken",
-                    "value": "0.3",
-                    "space": "lch"
-                  }
-                }
-              },
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.500}"
+              "$value": "{rhc.color.core.hover}"
             },
             "color": {
-              "$extensions": {
-                "studio.tokens": {
-                  "modify": {
-                    "type": "darken",
-                    "value": "0.3",
-                    "space": "lch"
-                  }
-                }
-              },
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.500}"
+              "$value": "{rhc.color.core.hover}"
             }
           },
           "background-color": {
@@ -8346,11 +8387,11 @@
           },
           "border-color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "disabled": {
             "background-color": {
@@ -8359,98 +8400,53 @@
             },
             "border-color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.200}"
+              "$value": "{rhc.color.core.200}"
             },
             "color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.300}"
+              "$value": "{rhc.color.core.300}"
             }
           },
           "focus": {
             "background-color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.50}"
+              "$value": "{rhc.color.core.50}"
             },
             "border-color": {
               "$type": "color",
               "$value": "{rhc.color.transparent}"
             },
             "color": {
-              "$extensions": {
-                "studio.tokens": {
-                  "modify": {
-                    "type": "darken",
-                    "value": "0.3",
-                    "space": "lch"
-                  }
-                }
-              },
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.500}"
+              "$value": "{rhc.color.core.500}"
             }
           },
           "active": {
             "background-color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.200}"
+              "$value": "{rhc.color.core.200}"
             },
             "border-color": {
-              "$extensions": {
-                "studio.tokens": {
-                  "modify": {
-                    "type": "darken",
-                    "value": "0.4",
-                    "space": "lch"
-                  }
-                }
-              },
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.500}"
+              "$value": "{rhc.color.core.active}"
             },
             "color": {
-              "$extensions": {
-                "studio.tokens": {
-                  "modify": {
-                    "type": "darken",
-                    "value": "0.3",
-                    "space": "lch"
-                  }
-                }
-              },
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.500}"
+              "$value": "{rhc.color.core.active}"
             }
           },
           "pressed": {
             "background-color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.100}"
+              "$value": "{rhc.color.core.100}"
             },
             "border-color": {
-              "$extensions": {
-                "studio.tokens": {
-                  "modify": {
-                    "type": "darken",
-                    "value": "0.4",
-                    "space": "lch"
-                  }
-                }
-              },
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.500}"
+              "$value": "{rhc.color.core.active}"
             },
             "color": {
-              "$extensions": {
-                "studio.tokens": {
-                  "modify": {
-                    "type": "darken",
-                    "value": "0.4",
-                    "space": "lch"
-                  }
-                }
-              },
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.500}"
+              "$value": "{rhc.color.core.active}"
             }
           }
         },
@@ -8458,24 +8454,15 @@
           "hover": {
             "background-color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.50}"
+              "$value": "{rhc.color.core.50}"
             },
             "border-color": {
               "$type": "color",
               "$value": "{rhc.color.transparent}"
             },
             "color": {
-              "$extensions": {
-                "studio.tokens": {
-                  "modify": {
-                    "type": "darken",
-                    "value": "0.3",
-                    "space": "lch"
-                  }
-                }
-              },
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.500}"
+              "$value": "{rhc.color.core.hover}"
             }
           },
           "background-color": {
@@ -8488,7 +8475,7 @@
           },
           "color": {
             "$type": "color",
-            "$value": "{rhc.color.lintblauw.500}"
+            "$value": "{rhc.color.core.500}"
           },
           "disabled": {
             "background-color": {
@@ -8501,76 +8488,49 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.100}"
+              "$value": "{rhc.color.core.100}"
             }
           },
           "focus": {
             "background-color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.50}"
+              "$value": "{rhc.color.core.50}"
             },
             "border-color": {
               "$type": "color",
               "$value": "{rhc.color.transparent}"
             },
             "color": {
-              "$extensions": {
-                "studio.tokens": {
-                  "modify": {
-                    "type": "darken",
-                    "value": "0.3",
-                    "space": "lch"
-                  }
-                }
-              },
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.500}"
+              "$value": "{rhc.color.core.500}"
             }
           },
           "active": {
             "background-color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.200}"
+              "$value": "{rhc.color.core.200}"
             },
             "border-color": {
               "$type": "color",
               "$value": "{rhc.color.transparent}"
             },
             "color": {
-              "$extensions": {
-                "studio.tokens": {
-                  "modify": {
-                    "type": "darken",
-                    "value": "0.4",
-                    "space": "srgb"
-                  }
-                }
-              },
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.500}"
+              "$value": "{rhc.color.core.active}"
             }
           },
           "pressed": {
             "background-color": {
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.100}"
+              "$value": "{rhc.color.core.100}"
             },
             "border-color": {
               "$type": "color",
               "$value": "{rhc.color.transparent}"
             },
             "color": {
-              "$extensions": {
-                "studio.tokens": {
-                  "modify": {
-                    "type": "darken",
-                    "value": "0.4",
-                    "space": "lch"
-                  }
-                }
-              },
               "$type": "color",
-              "$value": "{rhc.color.lintblauw.500}"
+              "$value": "{rhc.color.core.active}"
             }
           }
         }
@@ -8583,84 +8543,6 @@
         "font-size": {
           "$type": "fontSizes",
           "$value": "20px"
-        }
-      }
-    }
-  },
-  "overrides/primaire kleur/contrast fix/foreground op lichte kleur": {
-    "utrecht": {
-      "button": {
-        "primary-action": {
-          "color": {
-            "$type": "color",
-            "$value": "{rhc.color.foreground.on-light-color}"
-          },
-          "active": {
-            "color": {
-              "$type": "color",
-              "$value": "{rhc.color.foreground.on-light-color}"
-            }
-          },
-          "hover": {
-            "color": {
-              "$type": "color",
-              "$value": "{rhc.color.foreground.on-light-color}"
-            }
-          },
-          "focus": {
-            "color": {
-              "$type": "color",
-              "$value": "{rhc.color.foreground.on-light-color}"
-            }
-          },
-          "pressed": {
-            "color": {
-              "$type": "color",
-              "$value": "{rhc.color.foreground.on-light-color}"
-            }
-          }
-        }
-      },
-      "page-footer": {
-        "color": {
-          "$type": "color",
-          "$value": "{rhc.color.foreground.on-light-color}"
-        }
-      }
-    },
-    "rhc": {
-      "card-as-link": {
-        "horizontal": {
-          "color": {
-            "$type": "color",
-            "$value": "{rhc.color.foreground.on-light-color}"
-          }
-        }
-      },
-      "hero": {
-        "message": {
-          "color": {
-            "$type": "color",
-            "$value": "{rhc.color.foreground.on-light-color}"
-          }
-        }
-      },
-      "nav-bar": {
-        "link": {
-          "active": {
-            "color": {
-              "$type": "color",
-              "$value": "{rhc.color.foreground.on-light-color}"
-            }
-          }
-        },
-        "icon": {
-          "active": {
-            "color": {
-              "$type": "color",
-              "$value": "{rhc.color.foreground.on-light-color}"
-            }
-          }
         }
       }
     }
@@ -9955,7 +9837,6 @@
       "overrides/primaire kleur/violet",
       "overrides/primaire kleur/contrast fix/alle buttons lintblauw",
       "overrides/primaire kleur/contrast fix/button label groter",
-      "overrides/primaire kleur/contrast fix/foreground op lichte kleur",
       "overrides/primaire kleur/contrast fix/non primary button labels coolgrey",
       "overrides/primaire kleur/contrast fix/non primary buttons coolgrey",
       "overrides/responsive/min",

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -727,13 +727,11 @@
           },
           "600": {
             "$type": "color",
-            "$value": "oklch(38.54% 0.0857 238.6)",
-            "$description": "Originally rhc.color.donkerblauw.500 darkened (srgb) with modify by 0.3"
+            "$value": "oklch(38.54% 0.0857 238.6)"
           },
           "700": {
             "$type": "color",
-            "$value": "oklch(35.32% 0.0666 242.1)",
-            "$description": "Originally rhc.color.donkerblauw.500 darkened (lch) by 0.4"
+            "$value": "oklch(35.32% 0.0666 242.1)"
           }
         },
         "mintgroen": {
@@ -1084,6 +1082,14 @@
           "500": {
             "$type": "color",
             "$value": "oklch(37.619% 0.09695 253.44)"
+          },
+          "600": {
+            "$type": "color",
+            "$value": "oklch(30.37% 0.0676 256.1)"
+          },
+          "700": {
+            "$type": "color",
+            "$value": "oklch(28.03% 0.0577 258)"
           }
         }
       }
@@ -1515,13 +1521,11 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "oklch(30.37% 0.0676 256.1)",
-            "$description": "Originally rhc.color.primary.500 darkened (lch) by 0.3"
+            "$value": "{rhc.color.lintblauw.600}"
           },
           "active": {
             "$type": "color",
-            "$value": "oklch(28.03% 0.0577 258)",
-            "$description": "Originally rhc.color.primary.500 darkened (lch) by 0.4"
+            "$value": "{rhc.color.lintblauw.700}"
           }
         },
         "core": {
@@ -1551,13 +1555,11 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "oklch(30.37% 0.0676 256.1)",
-            "$description": "Originally rhc.color.primary.500 darkened (lch) by 0.3"
+            "$value": "{rhc.color.lintblauw.600}"
           },
           "active": {
             "$type": "color",
-            "$value": "oklch(28.03% 0.0577 258)",
-            "$description": "Originally rhc.color.primary.500 darkened (lch) by 0.4"
+            "$value": "{rhc.color.lintblauw.700}"
           }
         }
       }


### PR DESCRIPTION
Naast alles wat in de changeset staat ook wat extra dingen aangepast: 
- Transparant value aangepast naar brandtoken rhc.color.transparant
- Donkerblauw en lintblauw shades verplaatst naar brand tokenset voor consistentie. De andere kleuren volgen nog.
- Paar onnodige descriptions verwijderd. 