### PR TITLE
refactor: use Root component, not Document, in Storybook

### DIFF
--- a/.changeset/tall-clowns-wait.md
+++ b/.changeset/tall-clowns-wait.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/design-tokens': major
+---
+
+Remove `utrecht.body.*` tokens. Migrate to the new Root component to configure these design choices.

--- a/packages/storybook-angular/.storybook/preview.ts
+++ b/packages/storybook-angular/.storybook/preview.ts
@@ -30,7 +30,7 @@ const preview: Preview = {
   },
 
   decorators: [
-    componentWrapperDecorator((story) => `<div class="utrecht-document">${story}</div>`),
+    componentWrapperDecorator((story) => `<div class="utrecht-root">${story}</div>`),
     withThemeByClassName({
       themes: {
         'Kern - Lintblauw': 'rhc-theme',

--- a/packages/storybook/.storybook/preview.tsx
+++ b/packages/storybook/.storybook/preview.tsx
@@ -16,7 +16,6 @@ import { Controls, Description, Primary, Stories } from '@storybook/addon-docs/b
 import { useOf } from '@storybook/addon-docs/blocks';
 import { withThemeByClassName } from '@storybook/addon-themes';
 import { Preview } from '@storybook/react-vite';
-import { Document } from '@utrecht/component-library-react';
 import { Fragment } from 'react';
 import { StoryRootDecorator } from './StoryRootDecorator';
 
@@ -47,7 +46,7 @@ const preview: Preview = {
           </Body>
         </Root>
       ) : (
-        <Document>{Story()}</Document>
+        <Root Component="div">{Story()}</Root>
       );
     },
     StoryRootDecorator,

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -2422,28 +2422,6 @@
       }
     }
   },
-  "components/body": {
-    "utrecht": {
-      "body": {
-        "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{rhc.text.font-family.sans}"
-        },
-        "font-size": {
-          "$type": "fontSizes",
-          "$value": "{rhc.text.font-size.md}"
-        },
-        "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{rhc.text.font-weight.regular}"
-        },
-        "line-height": {
-          "$type": "lineHeights",
-          "$value": "{rhc.text.line-height.md}"
-        }
-      }
-    }
-  },
   "components/breadcrumb": {
     "utrecht": {
       "breadcrumb-nav": {
@@ -6637,6 +6615,18 @@
         "font-family": {
           "$type": "fontFamilies",
           "$value": "{rhc.text.font-family.sans}"
+        },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{rhc.text.font-size.md}"
+        },
+        "font-weight": {
+          "$type": "fontWeights",
+          "$value": "{rhc.text.font-weight.regular}"
+        },
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{rhc.text.line-height.md}"
         }
       }
     }
@@ -9127,7 +9117,6 @@
         "components/article": "enabled",
         "components/backdrop": "enabled",
         "components/blockquote": "enabled",
-        "components/body": "enabled",
         "components/breadcrumb": "enabled",
         "components/button": "enabled",
         "components/card": "enabled",
@@ -9219,7 +9208,6 @@
         "components/article": "enabled",
         "components/backdrop": "enabled",
         "components/blockquote": "enabled",
-        "components/body": "enabled",
         "components/breadcrumb": "enabled",
         "components/button": "enabled",
         "components/card": "enabled",
@@ -9312,7 +9300,6 @@
         "components/article": "enabled",
         "components/backdrop": "enabled",
         "components/blockquote": "enabled",
-        "components/body": "enabled",
         "components/breadcrumb": "enabled",
         "components/button": "enabled",
         "components/card": "enabled",
@@ -9405,7 +9392,6 @@
         "components/article": "enabled",
         "components/backdrop": "enabled",
         "components/blockquote": "enabled",
-        "components/body": "enabled",
         "components/breadcrumb": "enabled",
         "components/button": "enabled",
         "components/card": "enabled",
@@ -9500,7 +9486,6 @@
         "components/article": "enabled",
         "components/backdrop": "enabled",
         "components/blockquote": "enabled",
-        "components/body": "enabled",
         "components/breadcrumb": "enabled",
         "components/button": "enabled",
         "components/card": "enabled",
@@ -9593,7 +9578,6 @@
         "components/article": "enabled",
         "components/backdrop": "enabled",
         "components/blockquote": "enabled",
-        "components/body": "enabled",
         "components/breadcrumb": "enabled",
         "components/button": "enabled",
         "components/card": "enabled",


### PR DESCRIPTION
This change will cause all the screenshots to shift a bit, because of the new `font-size-adjust: 0.5`. This aligns Storybook with the rijkshuisstijl-community.nl website, where this already is being used.