### PR TITLE
feat: add border-radius tokens until 4xl

### DIFF
--- a/.changeset/cyan-teams-notice.md
+++ b/.changeset/cyan-teams-notice.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/design-tokens': minor
+---
+
+Add border radius tokens: `rhc.border-radius.lg` until `rhc.border-radius.4xl`.

--- a/packages/storybook/src/templates/design-tokens/border-radius.tsx
+++ b/packages/storybook/src/templates/design-tokens/border-radius.tsx
@@ -64,22 +64,6 @@ export default function Page() {
                           </TableCell>
                         </TableRow>
                       ))}
-                    {[
-                      { name: 'quarter-lint', value: tokens['rhc']['size']['quarter-lint'] },
-                      { name: 'half-lint', value: tokens['rhc']['size']['half-lint'] },
-                      { name: 'lint', value: tokens['rhc']['size']['lint'] },
-                      { name: '2-lint', value: tokens['rhc']['size']['2-lint'] },
-                      { name: '3-lint', value: tokens['rhc']['size']['3-lint'] },
-                    ].map(({ name, value }) => (
-                      <TableRow key={name}>
-                        <TableCell className="utrecht-table__cell--rhc-middle">
-                          <BorderRadiusSample value={value} />
-                        </TableCell>
-                        <TableCell className="utrecht-table__cell--rhc-middle">
-                          <CopyDesignTokenButton path={['rhc', 'size', name]} />
-                        </TableCell>
-                      </TableRow>
-                    ))}
                   </TableBody>
                 </Table>
               </div>

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -1944,6 +1944,26 @@
         "md": {
           "$type": "dimension",
           "$value": "5px"
+        },
+        "lg": {
+          "$type": "dimension",
+          "$value": "{rhc.size.quarter-lint}"
+        },
+        "xl": {
+          "$type": "dimension",
+          "$value": "{rhc.size.half-lint}"
+        },
+        "2xl": {
+          "$type": "dimension",
+          "$value": "{rhc.size.lint}"
+        },
+        "3xl": {
+          "$type": "dimension",
+          "$value": "{rhc.size.2-lint}"
+        },
+        "4xl": {
+          "$type": "dimension",
+          "$value": "{rhc.size.3-lint}"
         }
       }
     }


### PR DESCRIPTION
Voorstel om de border-radius design tokens simpeler te maken, door de verwijzingen naar het logo onder water te doen.

[Preview](https://rijkshuisstijl-community-templates-git-ca767a-nl-design-system.vercel.app/design-tokens/border-radius/)