### PR TITLE
feat: harden logo against custom `font-feature-settings`

### DIFF
--- a/.changeset/red-parents-dream.md
+++ b/.changeset/red-parents-dream.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/components-css': patch
+---
+
+Fix logo CSS to avoid "Hockeystick l"

--- a/packages/components-css/library-css/src/logo/_mixin.scss
+++ b/packages/components-css/library-css/src/logo/_mixin.scss
@@ -40,6 +40,9 @@
 
 @mixin rhc-logo__caption {
   color: var(--rhc-logo-color, inherit);
+
+  /* Harden against `font-feature-settings` configured, use the default font for the logotype */
+  font-feature-settings: normal;
   grid-area: caption;
   max-inline-size: var(--rhc-logo-caption-max-inline-size);
 }


### PR DESCRIPTION
Als je de Rijkshuisstijl font hebt geïnstalleerd:

Before, hockeystick l:

<img width="244" height="67" alt="Screenshot 2026-04-21 at 09 53 25" src="https://github.com/user-attachments/assets/a4f182c2-0aa0-43b4-9868-d117b5c40d9d" />

After, een I of een l:

<img width="234" height="80" alt="Screenshot 2026-04-21 at 09 53 21" src="https://github.com/user-attachments/assets/09bef4a6-f77e-46df-8af0-daa00fa6c1d7" />
