### PR TITLE
refactor: remove code covered by Root component

### DIFF
--- a/apps/rhc-templates/src/app/layout.css
+++ b/apps/rhc-templates/src/app/layout.css
@@ -1,8 +1,4 @@
 html:lang(nl) {
-  -webkit-hyphenate-limit-before: 8;
-  -webkit-hyphenate-limit-after: 4;
-  hyphenate-limit-chars: 12 8 4;
-
   -webkit-hyphenate-limit-lines: 2;
   hyphenate-limit-lines: 2;
 }

--- a/apps/rhc-templates/src/app/layout.tsx
+++ b/apps/rhc-templates/src/app/layout.tsx
@@ -4,7 +4,6 @@
  */
 
 import { PropsWithChildren } from 'react';
-import { Body } from '@utrecht/body-react';
 import { Root } from '@utrecht/root-react';
 import { PageLayout } from '@utrecht/page-layout-react';
 import type { Metadata } from 'next';
@@ -36,9 +35,9 @@ const themeModifiers = [
 export default function RootLayout({ children }: PropsWithChildren<{}>) {
   return (
     <Root lang="nl" dir="ltr" className={`rhc-theme rhc-theme--dark-mode ${themeModifiers}`}>
-      <Body>
+      <body>
         <PageLayout>{children}</PageLayout>
-      </Body>
+      </body>
     </Root>
   );
 }


### PR DESCRIPTION
- De hyphenation is nu onderdeel van Root
- De styling van `<body>` is nu onderdeel van Root

Geen changeset nodig, dit is alleen in de templates.