### PR TITLE
Doubly ensure packages are published with provenance

### DIFF
--- a/.changeset/dark-stars-ask.md
+++ b/.changeset/dark-stars-ask.md
@@ -1,0 +1,50 @@
+---
+'@rijkshuisstijl-community/data-summary-item-react': patch
+'@rijkshuisstijl-community/breadcrumb-nav-react': patch
+'@rijkshuisstijl-community/checkbox-group-react': patch
+'@rijkshuisstijl-community/action-group-react': patch
+'@rijkshuisstijl-community/card-as-link-react': patch
+'@rijkshuisstijl-community/data-summary-react': patch
+'@rijkshuisstijl-community/breadcrumb-nav-css': patch
+'@rijkshuisstijl-community/checkbox-group-css': patch
+'@rijkshuisstijl-community/blockquote-react': patch
+'@rijkshuisstijl-community/accordion-react': patch
+'@rijkshuisstijl-community/dot-badge-react': patch
+'@rijkshuisstijl-community/paragraph-react': patch
+'@rijkshuisstijl-community/separator-react': patch
+'@rijkshuisstijl-community/action-group-css': patch
+'@rijkshuisstijl-community/card-as-link-css': patch
+'@rijkshuisstijl-community/data-summary-css': patch
+'@rijkshuisstijl-community/checkbox-react': patch
+'@rijkshuisstijl-community/article-react': patch
+'@rijkshuisstijl-community/components-react': patch
+'@rijkshuisstijl-community/blockquote-css': patch
+'@rijkshuisstijl-community/button-react': patch
+'@rijkshuisstijl-community/figure-react': patch
+'@rijkshuisstijl-community/accordion-css': patch
+'@rijkshuisstijl-community/dot-badge-css': patch
+'@rijkshuisstijl-community/paragraph-css': patch
+'@rijkshuisstijl-community/separator-css': patch
+'@rijkshuisstijl-community/alert-react': patch
+'@rijkshuisstijl-community/image-react': patch
+'@rijkshuisstijl-community/checkbox-css': patch
+'@rijkshuisstijl-community/card-react': patch
+'@rijkshuisstijl-community/icon-react': patch
+'@rijkshuisstijl-community/link-react': patch
+'@rijkshuisstijl-community/article-css': patch
+'@rijkshuisstijl-community/components-css': patch
+'@rijkshuisstijl-community/button-css': patch
+'@rijkshuisstijl-community/figure-css': patch
+'@rijkshuisstijl-community/alert-css': patch
+'@rijkshuisstijl-community/card-css': patch
+'@rijkshuisstijl-community/link-css': patch
+'@rijkshuisstijl-community/components-angular': patch
+'@rijkshuisstijl-community/storybook-tooling': patch
+'@rijkshuisstijl-community/design-tokens': patch
+'@rijkshuisstijl-community/components-twig': patch
+'@rijkshuisstijl-community/web-components': patch
+'@rijkshuisstijl-community/assets': patch
+'@rijkshuisstijl-community/font': patch
+---
+
+Ensure package is published with provenance

--- a/apps/rhc-templates/package.json
+++ b/apps/rhc-templates/package.json
@@ -9,8 +9,7 @@
   ],
   "private": true,
   "publishConfig": {
-    "access": "restricted",
-    "registry": "https://registry.npmjs.org/"
+    "access": "restricted"
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -11,7 +11,8 @@
   "type": "module",
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -11,7 +11,6 @@
   "type": "module",
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/",
     "provenance": true
   },
   "repository": {

--- a/packages/components-css/accordion-css/package.json
+++ b/packages/components-css/accordion-css/package.json
@@ -26,7 +26,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-css/action-group-css/package.json
+++ b/packages/components-css/action-group-css/package.json
@@ -25,7 +25,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-css/alert-css/package.json
+++ b/packages/components-css/alert-css/package.json
@@ -26,7 +26,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-css/article-css/package.json
+++ b/packages/components-css/article-css/package.json
@@ -25,7 +25,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-css/blockquote-css/package.json
+++ b/packages/components-css/blockquote-css/package.json
@@ -25,7 +25,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-css/breadcrumb-nav-css/package.json
+++ b/packages/components-css/breadcrumb-nav-css/package.json
@@ -25,7 +25,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-css/button-css/package.json
+++ b/packages/components-css/button-css/package.json
@@ -26,7 +26,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-css/card-as-link-css/package.json
+++ b/packages/components-css/card-as-link-css/package.json
@@ -24,7 +24,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-css/card-css/package.json
+++ b/packages/components-css/card-css/package.json
@@ -24,7 +24,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-css/checkbox-css/package.json
+++ b/packages/components-css/checkbox-css/package.json
@@ -25,7 +25,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-css/checkbox-group-css/package.json
+++ b/packages/components-css/checkbox-group-css/package.json
@@ -24,7 +24,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-css/data-summary-css/package.json
+++ b/packages/components-css/data-summary-css/package.json
@@ -24,7 +24,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-css/dot-badge-css/package.json
+++ b/packages/components-css/dot-badge-css/package.json
@@ -24,7 +24,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-css/figure-css/package.json
+++ b/packages/components-css/figure-css/package.json
@@ -25,7 +25,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-css/library-css/package.json
+++ b/packages/components-css/library-css/package.json
@@ -11,7 +11,6 @@
   "private": false,
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/",
     "provenance": true
   },
   "repository": {

--- a/packages/components-css/library-css/package.json
+++ b/packages/components-css/library-css/package.json
@@ -11,7 +11,8 @@
   "private": false,
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-css/link-css/package.json
+++ b/packages/components-css/link-css/package.json
@@ -25,7 +25,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-css/paragraph-css/package.json
+++ b/packages/components-css/paragraph-css/package.json
@@ -25,7 +25,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-css/separator-css/package.json
+++ b/packages/components-css/separator-css/package.json
@@ -25,7 +25,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-react/accordion-react/package.json
+++ b/packages/components-react/accordion-react/package.json
@@ -36,7 +36,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-react/action-group-react/package.json
+++ b/packages/components-react/action-group-react/package.json
@@ -36,7 +36,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-react/alert-react/package.json
+++ b/packages/components-react/alert-react/package.json
@@ -36,7 +36,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-react/article-react/package.json
+++ b/packages/components-react/article-react/package.json
@@ -36,7 +36,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-react/blockquote-react/package.json
+++ b/packages/components-react/blockquote-react/package.json
@@ -35,7 +35,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-react/breadcrumb-nav-react/package.json
+++ b/packages/components-react/breadcrumb-nav-react/package.json
@@ -36,7 +36,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-react/button-react/package.json
+++ b/packages/components-react/button-react/package.json
@@ -36,7 +36,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-react/card-as-link-react/package.json
+++ b/packages/components-react/card-as-link-react/package.json
@@ -36,7 +36,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-react/card-react/package.json
+++ b/packages/components-react/card-react/package.json
@@ -36,7 +36,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-react/checkbox-group-react/package.json
+++ b/packages/components-react/checkbox-group-react/package.json
@@ -36,7 +36,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-react/checkbox-react/package.json
+++ b/packages/components-react/checkbox-react/package.json
@@ -36,7 +36,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-react/data-summary-item-react/package.json
+++ b/packages/components-react/data-summary-item-react/package.json
@@ -36,7 +36,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-react/data-summary-react/package.json
+++ b/packages/components-react/data-summary-react/package.json
@@ -36,7 +36,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-react/dot-badge-react/package.json
+++ b/packages/components-react/dot-badge-react/package.json
@@ -36,7 +36,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-react/figure-react/package.json
+++ b/packages/components-react/figure-react/package.json
@@ -36,7 +36,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-react/icon-react/package.json
+++ b/packages/components-react/icon-react/package.json
@@ -36,7 +36,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-react/image-react/package.json
+++ b/packages/components-react/image-react/package.json
@@ -36,7 +36,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-react/library-react/package.json
+++ b/packages/components-react/library-react/package.json
@@ -11,7 +11,8 @@
   "type": "module",
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-react/library-react/package.json
+++ b/packages/components-react/library-react/package.json
@@ -11,7 +11,6 @@
   "type": "module",
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/",
     "provenance": true
   },
   "repository": {

--- a/packages/components-react/link-react/package.json
+++ b/packages/components-react/link-react/package.json
@@ -36,7 +36,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-react/paragraph-react/package.json
+++ b/packages/components-react/paragraph-react/package.json
@@ -36,7 +36,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-react/separator-react/package.json
+++ b/packages/components-react/separator-react/package.json
@@ -36,7 +36,8 @@
     "rijkshuisstijl-community-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-twig/package.json
+++ b/packages/components-twig/package.json
@@ -11,7 +11,8 @@
   "type": "module",
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-twig/package.json
+++ b/packages/components-twig/package.json
@@ -11,7 +11,6 @@
   "type": "module",
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/",
     "provenance": true
   },
   "repository": {

--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -10,7 +10,8 @@
   "private": false,
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
   },
   "files": [
     "src",

--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -10,7 +10,6 @@
   "private": false,
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/",
     "provenance": true
   },
   "files": [

--- a/packages/storybook-tooling/package.json
+++ b/packages/storybook-tooling/package.json
@@ -6,7 +6,6 @@
   "types": "src/index.ts",
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/",
     "provenance": true
   },
   "scripts": {

--- a/packages/storybook-tooling/package.json
+++ b/packages/storybook-tooling/package.json
@@ -6,7 +6,8 @@
   "types": "src/index.ts",
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
   },
   "scripts": {
     "test": "vitest run --coverage --reporter verbose",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -9,8 +9,7 @@
   ],
   "private": true,
   "publishConfig": {
-    "access": "restricted",
-    "registry": "https://registry.npmjs.org/"
+    "access": "restricted"
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -10,7 +10,8 @@
   "private": false,
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
   },
   "main": "dist/index.mjs",
   "module": "dist/index.mjs",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -10,7 +10,6 @@
   "private": false,
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/",
     "provenance": true
   },
   "main": "dist/index.mjs",

--- a/proprietary/assets/package.json
+++ b/proprietary/assets/package.json
@@ -10,8 +10,7 @@
   "private": false,
   "publishConfig": {
     "access": "restricted",
-    "provenance": true,
-    "registry": "https://registry.npmjs.org/"
+    "provenance": true
   },
   "files": [],
   "repository": {

--- a/proprietary/assets/package.json
+++ b/proprietary/assets/package.json
@@ -10,7 +10,7 @@
   "private": false,
   "publishConfig": {
     "access": "restricted",
-    "provenance": false,
+    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   },
   "files": [],

--- a/proprietary/design-tokens/package.json
+++ b/proprietary/design-tokens/package.json
@@ -10,7 +10,8 @@
   "private": false,
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/design-tokens/package.json
+++ b/proprietary/design-tokens/package.json
@@ -10,7 +10,6 @@
   "private": false,
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/",
     "provenance": true
   },
   "repository": {


### PR DESCRIPTION
This is not strictly necessary, because there are other ways to configure provenance (notably .npmrc), but it helps with automated scripts and gives extra peace of mind.
