### PR TITLE
update SonarCloud configuration to exclude test files from duplication checks

### DIFF
--- a/.changeset/ninety-words-occur.md
+++ b/.changeset/ninety-words-occur.md
@@ -1,0 +1,5 @@
+---
+---
+chore: exclude test and locale files from SonarCloud duplication checks.
+
+Updated `.sonarcloud.properties` configuration to exclude test files (`**/*.test.ts*`, `**/*.spec.ts*`) and translation files (`**/locales/*.ts`) from copy-paste detection (CPD) in alignment with industry best practices.

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,15 @@
+# Path to sources
+#sonar.sources=.
+sonar.exclusions=**/index.html
+#sonar.inclusions=
+
+# Path to tests
+#sonar.tests=
+#sonar.test.exclusions=
+#sonar.test.inclusions=
+
+# Source encoding
+#sonar.sourceEncoding=UTF-8
+
+# Exclusions for copy-paste detection
+sonar.cpd.exclusions=**/index.html,**/*.test.ts*,**/*.spec.ts*,**/locales/*.ts


### PR DESCRIPTION
### Description
This PR updates the `.sonarcloud.properties` file to ignore test and locale (translation) files in copy-paste detection (CPD) checks. 

Test files and translation files naturally contain repetitive code and structures. Excluding them is a common practice to avoid unnecessary SonarCloud quality gate failures.

### Changes
- Added `**/*.test.ts*`, `**/*.spec.ts*`, and `**/locales/*.ts` to `sonar.cpd.exclusions` inside `.sonarcloud.properties`.

### Impact
Once merged, this will clean up the active SonarCloud duplication warnings for all test files across the project.
