### PR TITLE
chore: upgrade pnpm to 11 (+bonus: add husky)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Check for known security issues with npm packages
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm audit --audit-level critical --ignore-registry-errors
+          pnpm audit --audit-level critical
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,4 @@
-# This is an npm only setting. We do not use npm, but if it is run by accident, this setting prevents pre- and
-# post-install scripts from executing. This is aligns with pnpm's behaviour, where these scripts must be explicitly
-# approved with `pnpm approve-builds`.
+# We do not use npm, but if it was ever run by accident, this should make sure that pre- and post-install scripts will
+# NOT run. This is more or less in line with pnpm behaviour where pre- and post-install scripts need to be added using
+# pnpm approve-builds
 ignore-scripts=true
-
-provenance=true

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "engines": {
     "//": "Update @types/node to match the highest node version here",
     "node": ">=24 <=25",
-    "pnpm": "^10.17.0"
+    "pnpm": "^11.4.0"
   },
   "workspaces": [
     "./apps/**",
@@ -108,5 +108,5 @@
     "watch:sd": "pnpm run --recursive watch:style-dictionary",
     "test-storybook:ci": "pnpm --filter @rijkshuisstijl-community/storybook run playwright:install && pnpm --filter @rijkshuisstijl-community/storybook exec vitest run --project=storybook"
   },
-  "packageManager": "pnpm@10.30.1+sha512.3590e550d5384caa39bd5c7c739f72270234b2f6059e13018f975c313b1eb9fefcc09714048765d4d9efe961382c312e624572c0420762bdc5d5940cdf9be73a"
+  "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916"
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "eslint-plugin-sort-exports": "0.9.1",
     "eslint-plugin-unicorn": "64.0.0",
     "globals": "17.6.0",
+    "husky": "9.1.7",
     "lint-staged": "16.4.0",
     "markdownlint-cli": "0.48.0",
     "npm-check-updates": "19.6.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       globals:
         specifier: 17.6.0
         version: 17.6.0
+      husky:
+        specifier: 9.1.7
+        version: 9.1.7
       lint-staged:
         specifier: 16.4.0
         version: 16.4.0
@@ -289,8 +292,6 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
-
-  apps/rhc-templates/dist/dev: {}
 
   packages/build-utils-css:
     devDependencies:
@@ -16481,6 +16482,11 @@ packages:
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   hyperdyperid@1.2.0:
     resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
     engines: {node: '>=10.18'}
@@ -31781,6 +31787,8 @@ snapshots:
   humanize-ms@1.2.1:
     dependencies:
       ms: 2.1.3
+
+  husky@9.1.7: {}
 
   hyperdyperid@1.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,11 +1,20 @@
-# Edit this file by hand. Using `pnpm config` reformats the file and removes all comments.
-
 packages:
   - "apps/**"
   - "packages/*"
   - "packages/components-css/*"
   - "packages/components-react/*"
   - "proprietary/*"
+
+allowBuilds:
+  '@parcel/watcher': true
+  core-js: false
+  esbuild: true
+  fsevents: true
+  lmdb: true
+  msgpackr-extract: true
+  msw: true
+  sharp: true
+  unrs-resolver: true
 
 # Configure pnpm so peer dependencies are automatically installed.
 autoInstallPeers: true
@@ -74,3 +83,5 @@ overrides:
 
 # Configure pnpm to not fail when there are missing or invalid peer dependencies in the tree.
 strictPeerDependencies: false
+
+provenance: true


### PR DESCRIPTION
This PR upgrades pnpm to the latest version.  pnpm 11 has been out for a while now, and is now the recommended version to use.  Set the minimum version to 11.4 since that is the latest version with security fixes.  To use pnpm 11, ensure you're on a recent version of Node and run `corepack enable` in the root of the repository.

```sh
# to use the version of pnpm as specified in package.json
corepack enable
```

[pnpm 11](https://pnpm.io/blog/releases/11.0#highlights) comes with breaking changes and the [migration guide](https://pnpm.io/migration) was used.  It comes with better defaults for [strictDepBuilds](https://pnpm.io/settings#strictdepbuilds): you must now explicitly review which build scripts are allowed.  As well as `blockExoticSubdeps`.

The automigration moved all properties from `.npmrc` to `pnpm-workspace.yaml`, but we want to keep `ignore-scripts` as a safety measure and `provenance` because changeset publish bypasses pnpm.

`minimumReleaseAge` by default is now 24h, same as our existing setting.  I still kept it in `pnpm-workspace.yaml`, as it doesn't hurt to be explicit about it.

Also cleaned up the workaround in pipelines that allowed an RC version of pnpm to be used when the npm audit endpoint was down.  With pnpm 11, this is no longer needed.
