### PR TITLE
2719 link list   css nesting versimpelen

### DIFF
--- a/.changeset/orange-lamps-teach.md
+++ b/.changeset/orange-lamps-teach.md
@@ -3,4 +3,4 @@
 '@rijkshuisstijl-community/link-list-css': minor
 ---
 
-3 laags versimpelt naar 2 (met \_\_link)
+3 laags versimpeld naar 2 (met \_\_link)

--- a/.changeset/orange-lamps-teach.md
+++ b/.changeset/orange-lamps-teach.md
@@ -1,0 +1,6 @@
+---
+'@rijkshuisstijl-community/link-list-react': minor
+'@rijkshuisstijl-community/link-list-css': minor
+---
+
+3 laags versimpelt naar 2 (met \_\_link)

--- a/packages/components-angular/src/link-list-item/link-list-item.component.ts
+++ b/packages/components-angular/src/link-list-item/link-list-item.component.ts
@@ -6,6 +6,7 @@ import { Component } from '@angular/core';
   templateUrl: './link-list-item.component.html',
   host: {
     '[class.utrecht-link-list__item]': 'true',
+    '[class.rhc-link-list__item]': 'true',
   },
 })
 export class LinkListItemComponent {}

--- a/packages/components-css/link-list-css/src/index.scss
+++ b/packages/components-css/link-list-css/src/index.scss
@@ -3,26 +3,24 @@
  * Copyright (c) 2026 Community for NL Design System
  */
 
-.rhc-link-list {
-  .utrecht-link-list__link {
-    align-items: flex-start;
+.rhc-link-list__item .utrecht-link-list__link {
+  align-items: flex-start;
+}
 
-    .utrecht-icon {
-      align-items: center;
-      block-size: 1lh;
-      display: flex;
-      flex-shrink: 0;
-      position: static;
-    }
-  }
+.rhc-link-list__item .utrecht-icon {
+  align-items: center;
+  block-size: 1lh;
+  display: flex;
+  flex-shrink: 0;
+  position: static;
+}
 
-  .utrecht-link-list__item {
-    display: inline-flex;
-    font-family: var(--rhc-text-font-family-default, inherit);
-    font-size: var(--utrecht-link-list-item-font-size, inherit);
-  }
+.rhc-link-list__item {
+  display: inline-flex;
+  font-family: var(--rhc-text-font-family-default, inherit);
+  font-size: var(--utrecht-link-list-item-font-size, inherit);
+}
 
-  .utrecht-link-list__item .utrecht-link:any-link {
-    line-height: var(--rhc-text-line-height-md, inherit);
-  }
+.rhc-link-list__item .utrecht-link:any-link {
+  line-height: var(--rhc-text-line-height-md, inherit);
 }

--- a/packages/components-react/link-list-react/src/LinkList.tsx
+++ b/packages/components-react/link-list-react/src/LinkList.tsx
@@ -3,12 +3,17 @@
  * Copyright (c) 2026 Community for NL Design System
  */
 
-import { LinkList as UtrechtLinkList } from '@utrecht/component-library-react';
+import { LinkList as UtrechtLinkList, LinkListLink as UtrechtLinkListLink } from '@utrecht/component-library-react';
 import clsx from 'clsx';
 import { ComponentProps } from 'react';
 
-export { LinkListLink } from '@utrecht/component-library-react';
 export type { LinkListLinkProps, LinkListProps } from '@utrecht/component-library-react';
+
+export const LinkListLink = ({ className, ...restProps }: ComponentProps<typeof UtrechtLinkListLink>) => (
+  <UtrechtLinkListLink className={clsx('rhc-link-list__item', className)} {...restProps} />
+);
+
+LinkListLink.displayName = 'LinkListLink';
 
 export const LinkList = ({ className, ...restProps }: ComponentProps<typeof UtrechtLinkList>) => {
   return <UtrechtLinkList className={clsx('rhc-link-list', className)} {...restProps} />;


### PR DESCRIPTION
nesting versimpelt door __link toe te voegen als laag; hierdoor gaat het van 3 naar 2 laags (vanuit de import van utrecht)

Hoor graag hoe jullie hiernaar kijken.