### PR TITLE
feat(design-tokens): border-radius fijner afgestemd (sm 2px, md 4px)

### DIFF
--- a/.changeset/border-radius-sync.md
+++ b/.changeset/border-radius-sync.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/design-tokens': minor
+---
+
+Border-radius fijner afgestemd op het ontwerp: `rhc.border-radius.sm` van 2.5px naar 2px en `rhc.border-radius.md` van 5px naar 4px. Select en Table gebruiken nu `md` in plaats van `sm`.

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -2668,11 +2668,11 @@
       "border-radius": {
         "sm": {
           "$type": "dimension",
-          "$value": "2.5px"
+          "$value": "2px"
         },
         "md": {
           "$type": "dimension",
-          "$value": "5px"
+          "$value": "4px"
         }
       },
       "size": {
@@ -10904,7 +10904,7 @@
         },
         "border-radius": {
           "$type": "dimension",
-          "$value": "{rhc.border-radius.sm}"
+          "$value": "{rhc.border-radius.md}"
         },
         "border-width": {
           "$type": "dimension",
@@ -11626,7 +11626,7 @@
         },
         "border-radius": {
           "$type": "dimension",
-          "$value": "{rhc.border-radius.sm}"
+          "$value": "{rhc.border-radius.md}"
         },
         "border-width": {
           "$type": "dimension",
@@ -11824,7 +11824,7 @@
         },
         "border-radius": {
           "$type": "dimension",
-          "$value": "{rhc.border-radius.sm}"
+          "$value": "{rhc.border-radius.md}"
         },
         "border-width": {
           "$type": "dimension",


### PR DESCRIPTION
Stemt `rhc.border-radius.sm` (2.5px naar 2px) en `rhc.border-radius.md` (5px naar 4px) af op het ontwerp. Select en Table gebruiken nu `md` in plaats van `sm`.

Onderdeel van #2628.