### PR TITLE
fix(number-badge): achtergrondkleur volgt het kleurthema

### DIFF
--- a/.changeset/number-badge-primary-background.md
+++ b/.changeset/number-badge-primary-background.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/design-tokens': minor
+---
+
+Number-badge: de achtergrondkleur volgt nu het kleurthema (`primary` in plaats van de vaste `core`/lintblauw), zodat de badge per departement meekleurt. Overgenomen van de integratiebranch.

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -10101,7 +10101,7 @@
       "number-badge": {
         "background-color": {
           "$type": "color",
-          "$value": "{rhc.color.core.500}"
+          "$value": "{rhc.color.primary.500}"
         },
         "border-color": {
           "$type": "color",


### PR DESCRIPTION
De achtergrondkleur van de number-badge volgt nu het kleurthema: `{rhc.color.core.500}` → `{rhc.color.primary.500}`. Zo kleurt de badge per departement mee in plaats van vast op lintblauw te blijven.

Dit is de resolutie zoals die al op de integratiebranch (`integratie/test-alle-tickets`) staat, nu als losse wijziging tegen `main`.

Alleen een tokenwaarde in `components/number-badge/nl`; geen code- of CSS-wijziging.
