### PR TITLE
2803 margin tokens als reset op component - border-color toegevoed- invisible uit fixen 

### DIFF
--- a/.changeset/social-pans-tap.md
+++ b/.changeset/social-pans-tap.md
@@ -1,0 +1,5 @@
+---
+'@rijkshuisstijl-community/separator-css': major
+---
+
+Removed margin-inline-start and margin-inline-end styles from the component.

--- a/.changeset/social-pans-tap.md
+++ b/.changeset/social-pans-tap.md
@@ -1,5 +1,6 @@
 ---
 '@rijkshuisstijl-community/separator-css': major
+'@rijkshuisstijl-community/components-twig': major
 ---
 
 Removed margin-inline-start and margin-inline-end styles from the component.

--- a/.changeset/social-pans-tap.md
+++ b/.changeset/social-pans-tap.md
@@ -3,4 +3,4 @@
 '@rijkshuisstijl-community/components-twig': major
 ---
 
-Removed margin-inline-start and margin-inline-end styles from the component. Border-color is aangepast.
+Reset margin-inline-start and margin-inline-end. Border-color is aangepast.

--- a/.changeset/social-pans-tap.md
+++ b/.changeset/social-pans-tap.md
@@ -3,4 +3,4 @@
 '@rijkshuisstijl-community/components-twig': major
 ---
 
-Removed margin-inline-start and margin-inline-end styles from the component.
+Removed margin-inline-start and margin-inline-end styles from the component. Border-color is aangepast.

--- a/packages/components-css/separator-css/src/index.scss
+++ b/packages/components-css/separator-css/src/index.scss
@@ -6,8 +6,6 @@
 .rhc-separator.utrecht-separator {
   --utrecht-space-around: 1;
 
-  margin-inline-end: 0;
-  margin-inline-start: 0;
   &--invisible {
     --utrecht-separator-color: transparent;
   }

--- a/packages/components-css/separator-css/src/index.scss
+++ b/packages/components-css/separator-css/src/index.scss
@@ -7,6 +7,6 @@
   --utrecht-space-around: 1;
 
   border-color: var(--rhc-color-core), var(--rhc-color-core-300);
-  margin-inline-end: inherit;
-  margin-inline-start: inherit;
+  margin-inline-end: var(--rhc-space-none);
+  margin-inline-start: var(--rhc-space-none);
 }

--- a/packages/components-css/separator-css/src/index.scss
+++ b/packages/components-css/separator-css/src/index.scss
@@ -5,4 +5,5 @@
 
 .rhc-separator.utrecht-separator {
   --utrecht-space-around: 1;
+  border-color: var(--rhc-color-core), var(--rhc-color-core-300);
 }

--- a/packages/components-css/separator-css/src/index.scss
+++ b/packages/components-css/separator-css/src/index.scss
@@ -6,7 +6,6 @@
 .rhc-separator.utrecht-separator {
   --utrecht-space-around: 1;
 
-  border-color: var(--rhc-color-core, var(--rhc-color-core-300));
   margin-inline-end: var(--rhc-space-none);
   margin-inline-start: var(--rhc-space-none);
 }

--- a/packages/components-css/separator-css/src/index.scss
+++ b/packages/components-css/separator-css/src/index.scss
@@ -7,4 +7,6 @@
   --utrecht-space-around: 1;
 
   border-color: var(--rhc-color-core), var(--rhc-color-core-300);
+  margin-inline-end: inherit;
+  margin-inline-start: inherit;
 }

--- a/packages/components-css/separator-css/src/index.scss
+++ b/packages/components-css/separator-css/src/index.scss
@@ -5,5 +5,6 @@
 
 .rhc-separator.utrecht-separator {
   --utrecht-space-around: 1;
+
   border-color: var(--rhc-color-core), var(--rhc-color-core-300);
 }

--- a/packages/components-css/separator-css/src/index.scss
+++ b/packages/components-css/separator-css/src/index.scss
@@ -6,7 +6,7 @@
 .rhc-separator.utrecht-separator {
   --utrecht-space-around: 1;
 
-  border-color: var(--rhc-color-core), var(--rhc-color-core-300);
+  border-color: var(--rhc-color-core, var(--rhc-color-core-300));
   margin-inline-end: var(--rhc-space-none);
   margin-inline-start: var(--rhc-space-none);
 }

--- a/packages/components-twig/src/Separator.twig
+++ b/packages/components-twig/src/Separator.twig
@@ -1,3 +1,2 @@
 {%- set classes = ['utrecht-separator rhc-separator'] -%}
-{%- endif -%}
 <hr{{ attributes.addClass(classes) }}>

--- a/packages/storybook/src/components-react/separator.stories.tsx
+++ b/packages/storybook/src/components-react/separator.stories.tsx
@@ -20,13 +20,6 @@ const meta = {
     github:
       'https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/packages/components-react/src/Separator.tsx',
   },
-  argTypes: {
-    invisible: {
-      control: {
-        type: 'boolean',
-      },
-    },
-  },
 } satisfies Meta<typeof Separator>;
 
 export default meta;

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -11042,7 +11042,7 @@
         },
         "color": {
           "$type": "color",
-          "$value": "{rhc.color.cool-grey.300}"
+          "$value": "{rhc.color.core.300}"
         },
         "margin-block-end": {
           "$type": "dimension",


### PR DESCRIPTION
### PR: Fix separator visibility in SideNavigation and cleanup

#### Wat doet deze PR?
We hebben de  `invisible` optie verwijderd en het probleem opgelost waarbij de separator onzichtbaar werd binnen de `SideNavigation`.

#### De oplossing
* **Margins:** Vaste margins op de component vervangen door de global token `var(--abc-space-none, 0)`.
* **Border-color:** De juiste design token `var(--rhc-color-core-300)` toegevoegd zodat de lijn weer correct rendert.
* **Layout:** De verticale ruimte wordt nu netjes geregeld via de `row-gap` van de `SideNavigation`.

#### Wat we hebben geprobeerd (en waarom dat niet werkte)
* **Margins wissen:** Werkte niet. De browser pakte standaard `<hr>` margins en de lay-out ging stuk.
* **Margin-inline: inherit:** Werkte lokaal wel, maar maakt de component ongewenst afhankelijk van de parent (geeft later fouten in een Card of Modal).
* **Flex-shrink: 0:** Voorkwam dat de flexbox de lijn platdrukte, maar bleef een tijdelijke CSS-hack.

#### Conclusie
Door de combinatie van de juiste `border-color` en de officiële `space-none` token klopt het box-model weer automatisch. De flexbox drukt de hoogte niet meer naar `0px`, waardoor tijdelijke hacks zoals `inherit` of `flex-shrink: 0` definitief overbodig zijn. De component is nu volledig clean.

