### PR TITLE
Chore/eslint autofix and sonar rule

### DIFF
--- a/.changeset/setup-eslint-autofix.md
+++ b/.changeset/setup-eslint-autofix.md
@@ -3,4 +3,4 @@
 
 <!-- markdownlint-disable MD041 -->
 
-chore: add project-level ESLint auto-fix for lonely-if and integrate lint-staged for automated pre-commit code formatting.
+patch: add project-level ESLint auto-fix for lonely-if and integrate lint-staged for automated pre-commit code formatting.

--- a/.changeset/setup-eslint-autofix.md
+++ b/.changeset/setup-eslint-autofix.md
@@ -1,0 +1,6 @@
+---
+---
+
+<!-- markdownlint-disable MD041 -->
+
+chore: add project-level ESLint auto-fix for lonely-if and integrate lint-staged for automated pre-commit code formatting.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "js/ts.tsdk.path": "node_modules\\typescript\\lib",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "editor.formatOnSave": true
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -158,6 +158,7 @@ export default defineConfig([
       ...sharedRules,
       'no-unused-vars': 'off',
       '@typescript-eslint/no-unused-vars': 'error',
+      'no-lonely-if': 'error',
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -107,5 +107,11 @@
     "watch:sd": "pnpm run --recursive watch:style-dictionary",
     "test-storybook:ci": "pnpm --filter @rijkshuisstijl-community/storybook run playwright:install && pnpm --filter @rijkshuisstijl-community/storybook exec vitest run --project=storybook"
   },
+  "lint-staged": {
+    "*.{js,ts,jsx,tsx}": [
+      "eslint --fix --report-unused-disable-directives",
+      "prettier --write"
+    ]
+  },
   "packageManager": "pnpm@11.15.1+sha512.81350b07e53c9538a02f1f2303b4290fa2d7be04e56e2a970c4cc4b417dc761de196edabd49d55c7dc9580db81007c44143e4e3d7e462b3000d23c255122d065"
 }


### PR DESCRIPTION
Deze PR lost SonarQube-meldingen over code-stijl (zoals een losse if in een else-blok) automatisch voor ons op. Je hoeft hier zelf niet meer handmatig over na te denken.

**Wat is er veranderd?**

**ESLint (eslint.config.mjs):** 
De regel no-lonely-if staat aan. Code zoals else { if (x) } verandert nu automatisch in else if (x).
**VS Code (.vscode/settings.json):** 
Bij het opslaan (Ctrl+S) herstelt VS Code automatisch alle stijlfouten via ESLint.
**Commit bescherming (package.json):** 
Als je een andere editor gebruikt of handmatig commit, repareert lint-staged automatisch jouw gewijzigde bestanden via eslint --fix en prettier --write tijdens git commit.

**Voordelen voor het team**

**Geen gedoe met regels:** Schrijf code zoals je gewend bent, de tools op de achtergrond maken het automatisch schoon. Je wordt niet meer geblokkeerd tijdens het commiten.
**Snellere reviews:** We hoeven in PR's niet meer te praten over spaties of else-if structuren, maar puur over de logica en architectuur.
**Veilig:** Er verandert niks aan de werking van het project, we voegen alleen een slimme automatische assistent toe.